### PR TITLE
Récupération du nom vernaculaire français pour pouvoir réaliser des pérations de tri

### DIFF
--- a/src/lib/connectors/gbif.js
+++ b/src/lib/connectors/gbif.js
@@ -18,6 +18,26 @@ function callOccurrenceApi(params = {}) {
     return response.json();
   });
 }
+function callfetchVernacularName(taxonID) {
+  const mapping_language = { en: "eng", fr: "fra" };
+  const currentLanguage = ParameterStore.getInstance().lang.value;
+  return fetch(
+    `${GBIF_ENDPOINT_DEFAULT}/species/${taxonID}/vernacularNames?limit=100`
+  )
+    .then((response) => {
+      return response.json();
+    })
+    .then((data) => {
+      let name = undefined;
+      data.results.forEach((nameData) => {
+        if (nameData.language == mapping_language[currentLanguage]) {
+          name = nameData.vernacularName.capitalize();
+          return;
+        }
+      });
+      return name;
+    });
+}
 
 class GbifConnector extends Connector {
   GBIF_ENDPOINT;
@@ -54,7 +74,7 @@ class GbifConnector extends Connector {
       });
   }
 
-  fetchOccurrence(params) {
+  fetchOccurrenceRowData(params) {
     if (!params.limit) {
       params.limit = 300;
     }
@@ -116,6 +136,24 @@ class GbifConnector extends Connector {
           });
       });
       return taxonsData;
+    });
+  }
+
+  fetchOccurrence(params) {
+    return this.fetchOccurrenceRowData(params).then(async function (data) {
+      let promises = [];
+      let taxonList = {}
+      Object.keys(data).forEach((id_taxon) => {
+        promises.push(callfetchVernacularName(id_taxon).then(name => { data[id_taxon].vernacularName = name; return data[id_taxon] }));
+      });
+      await Promise.all(promises).then((data) => {
+        taxonList = data.reduce((taxonList, taxon) => {
+          taxonList[taxon.taxonId] = taxon;
+          return taxonList;
+        }, {});
+        console.log(taxonList)
+      });
+      return taxonList;
     });
   }
 


### PR DESCRIPTION
Le tri et filtre par nom vernaculaire ne peuvent fonctionner actuellement pour les noms français car ils sont récupérés dans un second temps. 

Pour réaliser cela, il faut au préalable récupérer les noms vernaculaires pour l'ensemble des données.