### PR TITLE
Media multi sources

### DIFF
--- a/src/assets/languageAssets/en.js
+++ b/src/assets/languageAssets/en.js
@@ -72,6 +72,10 @@ const messagesEN = {
     },
     desc: "Décroissant",
     asc: "Croissant",
+    media: {
+      source: "Media source",
+      select: "Select a media source",
+    },
     taxon: {
       scientificName: "Scientific Name",
       vernacularName: "Vernacular name",

--- a/src/assets/languageAssets/fr.js
+++ b/src/assets/languageAssets/fr.js
@@ -74,6 +74,10 @@ const messagesFR = {
     },
     desc: "Décroissant",
     asc: "Croissant",
+    media: {
+      source: "Source de médias",
+      select: "Sélectionner une source de média",
+    },
     taxon: {
       scientificName: "Nom scientifique",
       vernacularName: "Nom vernaculaire",

--- a/src/components/core/Filters.vue
+++ b/src/components/core/Filters.vue
@@ -1,11 +1,12 @@
 <script setup>
 import ParameterStore from "@/lib/parameterStore";
-
 // Components
 import TaxonClassFilter from "../commons/TaxonClassFilter.vue";
 import DateFilter from "./filters/DateFilter.vue";
 import BufferSizeFilter from "./filters/BufferSizeFilter.vue";
 import SourceFilter from "./filters/SourceFilter.vue";
+
+import MediaSourceSelector from "./filters/MediaSourceSelector.vue";
 
 const { dateMin, dateMax, showFilters } = ParameterStore.getInstance();
 </script>
@@ -45,6 +46,9 @@ const { dateMin, dateMax, showFilters } = ParameterStore.getInstance();
           <BFormCheckbox switch v-model="showFilters">{{
             $t("showFilters")
           }}</BFormCheckbox>
+        </div>
+        <div class="col mt-3">
+          <MediaSourceSelector> </MediaSourceSelector>
         </div>
       </div>
     </div>

--- a/src/components/core/TaxonList.vue
+++ b/src/components/core/TaxonList.vue
@@ -2,7 +2,6 @@
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import Loading from "@/components/commons/Loading.vue";
-import Pagination from "@/components/commons/Pagination.vue";
 import SortBy from "../commons/SortBy.vue";
 import SearchForm from "@/components/commons/SearchForm.vue";
 import sortArray from "sort-array";

--- a/src/components/core/TaxonList.vue
+++ b/src/components/core/TaxonList.vue
@@ -109,7 +109,7 @@ const fetchSpeciesList = (wkt) => {
   loadingObservations = true;
   loadingError = false;
   speciesList.value = [];
-  connector.value
+  connector
     .fetchOccurrence({
       geometry: wkt,
       dateMin: dateMin.value,

--- a/src/components/core/TaxonList.vue
+++ b/src/components/core/TaxonList.vue
@@ -101,10 +101,7 @@ const speciesListShowed = computed(() => {
   return sortArray(filteredSpecies, {
     by: sortBy.value,
     order: orderBy.value,
-  }).slice(
-    pageIndex.value * itemsPerPage.value,
-    (pageIndex.value + 1) * itemsPerPage.value
-  );
+  }).slice(0, (pageIndex.value + 1) * itemsPerPage.value);
 });
 
 const fetchSpeciesList = (wkt) => {
@@ -132,13 +129,21 @@ const fetchSpeciesList = (wkt) => {
     });
 };
 
-watch(pageIndex, () => {
-  document.getElementById("taxon-list-content").scrollTo({ top: 0, left: 0 });
-});
-
 watch(searchString, () => {
   pageIndex.value = 0;
 });
+
+function onScroll(event) {
+  const container = event.target;
+  const threshold = 50; // Seuil en pixels pour déclencher le chargement
+
+  if (
+    container.scrollTop + container.clientHeight >=
+    container.scrollHeight - threshold
+  ) {
+    pageIndex.value++;
+  }
+}
 
 watch([wkt, class_, dateMin, dateMax, connector], () => {
   if (wkt.value) {
@@ -194,7 +199,7 @@ if (wkt.value) {
       <div id="loading-error" class="col-6 bg-danger" v-if="loadingError">
         <h5><i class="bi bi-bug"></i> Erreur de chargement des données</h5>
       </div>
-      <div id="taxon-list-content" :class="classNames">
+      <div id="taxon-list-content" :class="classNames" @scroll="onScroll">
         <div class="justify-content-center toggleMode">
           <button class="btn btn-secondary" @click="toggleMode()">
             <i v-if="mode === 'gallery'" class="fa-solid fa-list"></i>
@@ -208,14 +213,7 @@ if (wkt.value) {
         />
       </div>
     </div>
-    <div v-if="speciesListShowed.length" class="card-footer">
-      <Pagination
-        :pageIndex="pageIndex"
-        :total-items="speciesList.length"
-        :itemPerPage="itemsPerPage"
-        @update:page="(index) => (pageIndex = index)"
-      />
-    </div>
+
     <div id="data-source-credits">
       {{ $t("source.title") }} {{ connector.name }}
       <BTooltip>

--- a/src/components/core/TaxonThumbnail.vue
+++ b/src/components/core/TaxonThumbnail.vue
@@ -45,7 +45,6 @@ const props = defineProps({
 <style scoped>
 .card {
   border: 0;
-  margin-bottom: 1em;
   align-content: space-around;
 }
 .card-img {

--- a/src/components/core/TaxonView.vue
+++ b/src/components/core/TaxonView.vue
@@ -54,15 +54,16 @@ watch(lang, () => {
   <TaxonThumbnail
     v-if="mode == 'gallery'"
     :media="mediaDisplayed"
-    :vernacular-name="vernacularName ?? taxon.acceptedScientificName"
+    :vernacular-name="vernacularName || taxon.acceptedScientificName"
     :url-detail-page="connector.getTaxonDetailPage(taxon.taxonId)"
+    :accepted-scientific-name="taxon.acceptedScientificName"
   >
   </TaxonThumbnail>
   <TaxonDetailed
     v-else
     :media="mediaDisplayed"
     :accepted-scientific-name="taxon.acceptedScientificName"
-    :vernacular-name="vernacularName ?? taxon.acceptedScientificName"
+    :vernacular-name="vernacularName || taxon.acceptedScientificName"
     :url-detail-page="connector.getTaxonDetailPage(taxon.taxonId)"
     :nb-observations="taxon?.nbObservations"
     :last-seen-date="taxon?.lastSeenDate"

--- a/src/components/core/TaxonView.vue
+++ b/src/components/core/TaxonView.vue
@@ -23,19 +23,22 @@ const vernacularName = ref(taxon.vernacularName);
 function fetchTaxonImage() {
   speciesPhoto.value = [];
   if (taxon.taxonId) {
-    connector.value.fetchMedia(taxon.taxonId).then((response) => {
+    connector.fetchMedia(taxon.taxonId).then((response) => {
       speciesPhoto.value = response;
     });
   }
 }
 const mediaDisplayed = computed(() => {
+  if (!speciesPhoto.value) {
+    return new Media({ url: NO_IMAGE_URL });
+  }
   return speciesPhoto.value.length == 0
     ? new Media({ url: NO_IMAGE_URL })
     : randomChoice(speciesPhoto.value);
 });
 
 function refreshVernacularName() {
-  connector.value.fetchVernacularName(taxon.taxonId).then((name) => {
+  connector.fetchVernacularName(taxon.taxonId).then((name) => {
     if (name) {
       vernacularName.value = name.split(",")[0];
     }

--- a/src/components/core/filters/MediaSourceSelector.vue
+++ b/src/components/core/filters/MediaSourceSelector.vue
@@ -1,0 +1,25 @@
+<script setup>
+import ParameterStore from "@/lib/parameterStore";
+import { ref, watch } from "vue";
+import { getMediaSource } from "@/lib/media/media";
+const { connector } = ParameterStore.getInstance();
+
+const mediaSourceID = ref(connector.mediaSource.id);
+watch(mediaSourceID, () => {
+  connector.mediaSource = getMediaSource(mediaSourceID.value);
+});
+</script>
+<template>
+  <label for="mediaSourceSelect">{{ $t("media.source") }}</label>
+  <BFormSelect
+    id="mediaSourceSelect"
+    :options="connector.getCompatibleMediaSource()"
+    v-model="mediaSourceID"
+  >
+    <template #first>
+      <BFormSelectOption :value="null" disabled>{{
+        $t("media.select")
+      }}</BFormSelectOption>
+    </template>
+  </BFormSelect>
+</template>

--- a/src/components/core/filters/SourceFilter.vue
+++ b/src/components/core/filters/SourceFilter.vue
@@ -25,7 +25,7 @@ const sources = {
   ],
 };
 
-const sourceName = ref(connector.value.name);
+const sourceName = ref(connector.name);
 let params = reactive(
   Object.fromEntries(
     sources[sourceName.value].map((form) => [form.name, form.default])
@@ -41,7 +41,7 @@ watch([sourceName], () => {
 });
 
 function updateSource(a) {
-  connector.value = getConnector(sourceName.value, params);
+  connector = getConnector(sourceName.value, params);
 }
 </script>
 

--- a/src/lib/connectors/connector.js
+++ b/src/lib/connectors/connector.js
@@ -3,6 +3,7 @@ import { toast } from "vue3-toastify";
 class Connector {
   name;
   taxonClass2SourceID = {};
+  referential;
 
   constructor(options) {
     this.options = options;

--- a/src/lib/connectors/connector.js
+++ b/src/lib/connectors/connector.js
@@ -33,6 +33,7 @@ class Connector {
             "mediaSource",
           ].includes(key)
       )
+      .filter(([key, value]) => typeof value != typeof {})
       .forEach(([key, value]) => {
         params[key] = value;
       });

--- a/src/lib/connectors/connector.js
+++ b/src/lib/connectors/connector.js
@@ -16,6 +16,25 @@ class Connector {
       }
     });
   }
+
+  getParams() {
+    const params = {};
+    Object.entries(this)
+      .filter(
+        ([key, _]) =>
+          ![
+            "options",
+            "params",
+            "name",
+            "taxonClass2SourceID",
+            "referential",
+          ].includes(key)
+      )
+      .forEach(([key, value]) => {
+        params[key] = value;
+      });
+    return params;
+  }
   /**
    * Fetches occurrences based on the given parameters.
    * @param {Object} params - The parameters for the occurrence query.

--- a/src/lib/connectors/connector.js
+++ b/src/lib/connectors/connector.js
@@ -1,4 +1,5 @@
 import { toast } from "vue3-toastify";
+import { getMediaSource } from "../media/media";
 
 class Connector {
   name;
@@ -7,7 +8,8 @@ class Connector {
 
   constructor(options) {
     this.options = options;
-    this.params = this.options;
+
+    this.mediaSource = options?.mediaSource;
   }
   verifyOptions(params_names = []) {
     params_names.forEach((name) => {
@@ -28,11 +30,15 @@ class Connector {
             "name",
             "taxonClass2SourceID",
             "referential",
+            "mediaSource",
           ].includes(key)
       )
       .forEach(([key, value]) => {
         params[key] = value;
       });
+    if (this.mediaSource) {
+      params["mediaSource"] = this.mediaSource.id;
+    }
     return params;
   }
   /**
@@ -50,7 +56,10 @@ class Connector {
    * @returns {Promise<Array>} A promise that resolves to the list of media.
    */
   fetchMedia(idTaxon) {
-    throw new Error("Not implemented");
+    if (!this.mediaSource.isCompatible(this))
+      throw new Error("Media Source incompatible");
+
+    return this.mediaSource.fetchPicture(idTaxon, this);
   }
 
   /**

--- a/src/lib/connectors/connector.js
+++ b/src/lib/connectors/connector.js
@@ -1,5 +1,5 @@
 import { toast } from "vue3-toastify";
-import { getMediaSource } from "../media/media";
+import { getMediaSource, SOURCE_ } from "../media/media";
 
 class Connector {
   name;
@@ -112,6 +112,20 @@ class Connector {
    */
   sourceDetailMessage() {
     return "";
+  }
+  getCompatibleMediaSource() {
+    const availableSource = [];
+    Object.values(SOURCE_)
+      .filter((idMediaSource) =>
+        getMediaSource(idMediaSource).isCompatible(this)
+      )
+      .forEach((idMediaSource) => {
+        availableSource.push({
+          value: idMediaSource,
+          text: getMediaSource(idMediaSource).name,
+        });
+      });
+    return availableSource;
   }
 }
 

--- a/src/lib/connectors/gbif.js
+++ b/src/lib/connectors/gbif.js
@@ -142,11 +142,6 @@ class GbifConnector extends Connector {
     });
   }
 
-  fetchMedia(idTaxon) {
-    const mediaSource = new GBIFMediaSource();
-    return mediaSource.fetchMedia(idTaxon, this);
-  }
-
   fetchTaxonInfo(idTaxon) {
     const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}?language=${this.language}`;
     return fetch(url)

--- a/src/lib/connectors/gbif.js
+++ b/src/lib/connectors/gbif.js
@@ -5,6 +5,7 @@ import { NO_IMAGE_URL } from "@/assets/constant";
 import { TAXON_REFERENTIAL } from "../taxonReferential";
 import { WikiDataImageSource } from "../media/Wikidata";
 import { GBIFMediaSource } from "../media/Gbif";
+import { getMediaSource, SOURCE_ } from "../media/media";
 
 const GBIF_ENDPOINT_DEFAULT = "https://api.gbif.org/v1";
 
@@ -34,6 +35,8 @@ class GbifConnector extends Connector {
     this.name = "GBIF";
     this.GBIF_ENDPOINT = this.options.GBIF_ENDPOINT || GBIF_ENDPOINT_DEFAULT;
     this.referential = TAXON_REFERENTIAL.GBIF;
+    this.mediaSource = this.mediaSource || getMediaSource(SOURCE_.GBIF);
+
     this.taxonClass2SourceID = {
       Aves: 212,
       Mammalia: 359,

--- a/src/lib/connectors/gbif.js
+++ b/src/lib/connectors/gbif.js
@@ -2,6 +2,9 @@ import { Connector } from "./connector";
 import { Media, Taxon } from "../models";
 import ParameterStore from "../parameterStore";
 import { NO_IMAGE_URL } from "@/assets/constant";
+import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { WikiDataImageSource } from "../media/Wikidata";
+import { GBIFMediaSource } from "../media/Gbif";
 
 const GBIF_ENDPOINT_DEFAULT = "https://api.gbif.org/v1";
 
@@ -30,6 +33,7 @@ class GbifConnector extends Connector {
     super(options);
     this.name = "GBIF";
     this.GBIF_ENDPOINT = this.options.GBIF_ENDPOINT || GBIF_ENDPOINT_DEFAULT;
+    this.referential = TAXON_REFERENTIAL.GBIF;
     this.taxonClass2SourceID = {
       Aves: 212,
       Mammalia: 359,
@@ -139,52 +143,8 @@ class GbifConnector extends Connector {
   }
 
   fetchMedia(idTaxon) {
-    const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}/media`;
-    return fetch(url)
-      .then((response) => response.json())
-      .then((json) => {
-        let mediaList = this.processMedia(json.results);
-        if (mediaList.length === 0) {
-          return this.fetchMediaOccurence(idTaxon);
-        }
-        return mediaList;
-      });
-  }
-  /**
-   * Fetches media from occurrences of a taxon ID
-   * @param {string} idTaxon - The ID of the taxon.
-   * @returns {Promise<Array>} A promise that resolves to the list of media.
-   */
-  fetchMediaOccurence(idTaxon) {
-    const url = `${this.GBIF_ENDPOINT}/occurrence/search?limit=10&mediaType=StillImage&speciesKey=${idTaxon}`;
-    return fetch(url)
-      .then((response) => response.json())
-      .then((json) => {
-        const medias = json.results.flatMap((element) => element.media);
-        return this.processMedia(medias);
-      });
-  }
-
-  /**
-   * Fetch medias with licence and rights holder informations
-   * @param {Array} medias - The media data to process.
-   * @returns {Array} The list of Media objects.
-   */
-  processMedia(medias) {
-    return Object.values(medias)
-      .filter(
-        (media) =>
-          media.hasOwnProperty("license") &&
-          media.hasOwnProperty("rightsHolder")
-      )
-      .map(
-        (media) =>
-          new Media({
-            url: media.identifier,
-            licence: media.licence,
-            source: `${media.rightsHolder} (${media.license})`,
-          })
-      );
+    const mediaSource = new GBIFMediaSource();
+    return mediaSource.fetchMedia(idTaxon, this);
   }
 
   fetchTaxonInfo(idTaxon) {

--- a/src/lib/connectors/geonature.js
+++ b/src/lib/connectors/geonature.js
@@ -2,6 +2,7 @@ import { Connector } from "./connector";
 import { Taxon } from "../models";
 import { NO_IMAGE_URL } from "@/assets/constant";
 import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { getMediaSource, SOURCE_ } from "../media/media";
 class GeoNatureConnector extends Connector {
   EXPORT_API_ENDPOINT;
 
@@ -11,6 +12,7 @@ class GeoNatureConnector extends Connector {
     // this.verifyOptions(["EXPORT_API_ENDPOINT"]);
     this.EXPORT_API_ENDPOINT = options?.EXPORT_API_ENDPOINT;
     this.referential = TAXON_REFERENTIAL.TAXREF;
+    this.mediaSource = this.mediaSource ?? getMediaSource(SOURCE_.TAXREF_ODATA);
   }
 
   fetchOccurrence(params = {}) {

--- a/src/lib/connectors/geonature.js
+++ b/src/lib/connectors/geonature.js
@@ -1,6 +1,7 @@
 import { Connector } from "./connector";
 import { Taxon } from "../models";
 import { NO_IMAGE_URL } from "@/assets/constant";
+import { TAXON_REFERENTIAL } from "../taxonReferential";
 class GeoNatureConnector extends Connector {
   EXPORT_API_ENDPOINT;
 
@@ -9,6 +10,7 @@ class GeoNatureConnector extends Connector {
     this.name = "GeoNature";
     // this.verifyOptions(["EXPORT_API_ENDPOINT"]);
     this.EXPORT_API_ENDPOINT = options?.EXPORT_API_ENDPOINT;
+    this.referential = TAXON_REFERENTIAL.TAXREF;
   }
 
   fetchOccurrence(params = {}) {

--- a/src/lib/connectors/geonature.js
+++ b/src/lib/connectors/geonature.js
@@ -54,28 +54,6 @@ class GeoNatureConnector extends Connector {
       });
   }
 
-  fetchMedia(idTaxon) {
-    const url = `https://odata-inpn.mnhn.fr/photos/taxa?taxrefId=${idTaxon}&visibility=PUBLIC`;
-    return fetch(url)
-      .then((response) => {
-        return response.json();
-      })
-      .then(function (json) {
-        let mediaList = [];
-        try {
-          Object.values(json?._embedded?.photos).forEach((media) => {
-            mediaList.push({
-              url: media._links.thumbnail.href,
-              licence: media.licence,
-              source: media.copyright,
-            });
-          });
-          return mediaList;
-        } catch {
-          return [];
-        }
-      });
-  }
   fetchTaxonInfo(idTaxon) {
     const url = `https://odata-inpn.mnhn.fr/taxa/${idTaxon}`; //
     return fetch(url)

--- a/src/lib/connectors/utils.js
+++ b/src/lib/connectors/utils.js
@@ -1,7 +1,11 @@
+import { getMediaSource } from "../media/media";
 import { GbifConnector } from "./gbif";
 import { GeoNatureConnector } from "./geonature";
 
 function getConnector(connectorName = "GBIF", params = {}) {
+  if (params.hasOwnProperty("mediaSource")) {
+    params["mediaSource"] = getMediaSource(params.mediaSource);
+  }
   switch (connectorName) {
     case "GBIF":
       return new GbifConnector(params);

--- a/src/lib/media/Gbif.js
+++ b/src/lib/media/Gbif.js
@@ -1,12 +1,21 @@
 import { Media } from "../models";
 import { MediaSource } from "./MediaSource";
 import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { SOURCE_ } from "./media";
 
 export class GBIFMediaSource extends MediaSource {
   constructor(parameters) {
-    super("GBIFMediaSource");
+    super("GBIFMediaSource", SOURCE_.GBIF);
   }
-  fetchMedia(taxonID, connector) {
+  isCompatible(connector) {
+    return connector.referential == TAXON_REFERENTIAL.GBIF ? true : false;
+  }
+  fetchPicture(taxonID, connector) {
+    if (!this.isCompatible(connector)) {
+      throw new Error(
+        `The connector ${connector.name} is not available for the GBIF Media Source`
+      );
+    }
     const url = `${connector.GBIF_ENDPOINT}/species/${taxonID}/media`;
     return fetch(url)
       .then((response) => response.json())
@@ -54,8 +63,5 @@ export class GBIFMediaSource extends MediaSource {
         const medias = json.results.flatMap((element) => element.media);
         return this.processMedia(medias);
       });
-  }
-  isCompatible(connector) {
-    return connector.referential == TAXON_REFERENTIAL.GBIF ? true : false;
   }
 }

--- a/src/lib/media/Gbif.js
+++ b/src/lib/media/Gbif.js
@@ -1,0 +1,61 @@
+import { Media } from "../models";
+import { MediaSource } from "./MediaSource";
+import { TAXON_REFERENTIAL } from "../taxonReferential";
+
+export class GBIFMediaSource extends MediaSource {
+  constructor(parameters) {
+    super("GBIFMediaSource");
+  }
+  fetchMedia(taxonID, connector) {
+    const url = `${connector.GBIF_ENDPOINT}/species/${taxonID}/media`;
+    return fetch(url)
+      .then((response) => response.json())
+      .then((json) => {
+        let mediaList = this.processMedia(json.results);
+        if (mediaList.length === 0) {
+          return this.fetchMediaOccurence(taxonID, connector.GBIF_ENDPOINT);
+        }
+        return mediaList;
+      });
+  }
+
+  /**
+   * Fetch medias with licence and rights holder informations
+   * @param {Array} medias - The media data to process.
+   * @returns {Array} The list of Media objects.
+   */
+  processMedia(medias) {
+    return Object.values(medias)
+      .filter(
+        (media) =>
+          media.hasOwnProperty("license") &&
+          media.hasOwnProperty("rightsHolder")
+      )
+      .map(
+        (media) =>
+          new Media({
+            url: media.identifier,
+            licence: media.licence,
+            source: `${media.rightsHolder} (${media.license})`,
+          })
+      );
+  }
+
+  /**
+   * Fetches media from occurrences of a taxon ID
+   * @param {string} idTaxon - The ID of the taxon.
+   * @returns {Promise<Array>} A promise that resolves to the list of media.
+   */
+  fetchMediaOccurence(idTaxon, ENDPOINT) {
+    const url = `${ENDPOINT}/occurrence/search?limit=10&mediaType=StillImage&speciesKey=${idTaxon}`;
+    return fetch(url)
+      .then((response) => response.json())
+      .then((json) => {
+        const medias = json.results.flatMap((element) => element.media);
+        return this.processMedia(medias);
+      });
+  }
+  isCompatible(connector) {
+    return connector.referential == TAXON_REFERENTIAL.GBIF ? true : false;
+  }
+}

--- a/src/lib/media/MediaSource.js
+++ b/src/lib/media/MediaSource.js
@@ -1,10 +1,21 @@
+import { SOURCE_ } from "./media";
+
 export class MediaSource {
   name;
-  constructor(name) {
+  constructor(name, id) {
     this.name = name;
+    if (!Object.values(SOURCE_).includes(id)) {
+      throw new Error(
+        "Source identifier is not declared in `mediaIdentifier.js`"
+      );
+    }
+    this.id = id;
   }
 
-  fetchMedia(taxonID, connector) {
+  fetchPicture(taxonID, connector) {
+    if (!this.isCompatible(connector)) {
+      throw new Error("This media source is not available !");
+    }
     throw new Error("Not implemented");
   }
   isCompatible(connector) {

--- a/src/lib/media/MediaSource.js
+++ b/src/lib/media/MediaSource.js
@@ -1,0 +1,13 @@
+export class MediaSource {
+  name;
+  constructor(name) {
+    this.name = name;
+  }
+
+  fetchMedia(taxonID, connector) {
+    throw new Error("Not implemented");
+  }
+  isCompatible(connector) {
+    throw new Error("Not Implemented");
+  }
+}

--- a/src/lib/media/Taxref.js
+++ b/src/lib/media/Taxref.js
@@ -1,12 +1,13 @@
 import { Media } from "../models";
 import { MediaSource } from "./MediaSource";
 import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { SOURCE_ } from "./media";
 
 export class TaxrefODATA extends MediaSource {
   constructor(parameters) {
-    super("Taxref");
+    super("Taxref", SOURCE_.TAXREF_ODATA);
   }
-  fetchMedia(taxonID, connector) {
+  fetchPicture(taxonID, connector) {
     const url = `https://odata-inpn.mnhn.fr/photos/taxa?taxrefId=${taxonID}&visibility=PUBLIC`;
     return fetch(url)
       .then((response) => {

--- a/src/lib/media/Taxref.js
+++ b/src/lib/media/Taxref.js
@@ -1,0 +1,36 @@
+import { Media } from "../models";
+import { MediaSource } from "./MediaSource";
+import { TAXON_REFERENTIAL } from "../taxonReferential";
+
+export class TaxrefODATA extends MediaSource {
+  constructor(parameters) {
+    super("Taxref");
+  }
+  fetchMedia(taxonID, connector) {
+    const url = `https://odata-inpn.mnhn.fr/photos/taxa?taxrefId=${taxonID}&visibility=PUBLIC`;
+    return fetch(url)
+      .then((response) => {
+        return response.json();
+      })
+      .then(function (json) {
+        let mediaList = [];
+        try {
+          Object.values(json?._embedded?.photos).forEach((media) => {
+            mediaList.push(
+              new Media({
+                url: media._links.thumbnail.href,
+                licence: media.licence,
+                source: media.copyright,
+              })
+            );
+          });
+          return mediaList;
+        } catch {
+          return [];
+        }
+      });
+  }
+  isCompatible(connector) {
+    return connector.referential == TAXON_REFERENTIAL.TAXREF ? true : false;
+  }
+}

--- a/src/lib/media/UrlMediaSource.js
+++ b/src/lib/media/UrlMediaSource.js
@@ -1,6 +1,6 @@
 export class UrlMediaSource extends MediaSource {
   constructor(params) {
-    this.name = "UrlMediaSource";
+    super("UrlMediaSource");
     this.url = params.urlTemplate;
   }
 

--- a/src/lib/media/UrlMediaSource.js
+++ b/src/lib/media/UrlMediaSource.js
@@ -1,0 +1,57 @@
+export class UrlMediaSource extends MediaSource {
+  constructor(params) {
+    this.name = "UrlMediaSource";
+    this.url = params.urlTemplate;
+  }
+
+  isCompatible(connector) {
+    return true;
+  }
+
+  fetchMedia(taxonID) {
+    const apiUrl = this.url.replace("{taxonID}", taxonID);
+    return fetch(apiUrl)
+      .then((response) => response.json())
+      .then((data) => {
+        const imageUrl = this.findImageUrlInResponse(data);
+        if (!imageUrl) {
+          console.log("Aucune URL d'image trouvée dans la réponse de l'API.");
+          return Promise.reject("Aucune URL d'image trouvée.");
+        }
+        console.log("URL de l'image trouvée :", imageUrl);
+        return imageUrl;
+      })
+      .catch((error) => {
+        console.error(
+          "Erreur lors de la récupération de l'URL de l'image :",
+          error
+        );
+        return Promise.reject(error);
+      });
+  }
+
+  findImageUrlInResponse(data) {
+    if (typeof data === "object") {
+      for (const key in data) {
+        if (key.includes("image") || key.includes("url")) {
+          const value = data[key];
+          if (
+            typeof value === "string" &&
+            (value.endsWith(".jpg") ||
+              value.endsWith(".png") ||
+              value.endsWith(".jpeg") ||
+              value.includes("wikimedia"))
+          ) {
+            return value;
+          }
+        } else if (typeof data[key] === "object") {
+          const nestedUrl = this.findImageUrlInResponse(data[key]);
+          if (nestedUrl) {
+            return nestedUrl;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/lib/media/Wikidata.js
+++ b/src/lib/media/Wikidata.js
@@ -1,0 +1,116 @@
+import { Media } from "../models";
+import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { MediaSource } from "./MediaSource";
+
+const { GBIF, TAXREF } = TAXON_REFERENTIAL;
+
+function fetchWikidataEntityByTaxrefId(cdNom) {
+  const url = "https://query.wikidata.org/sparql";
+  const query = `
+    SELECT ?item WHERE {
+      ?item wdt:P3186 "${cdNom}" .
+    }`;
+
+  return fetch(url + "?format=json&query=" + encodeURIComponent(query))
+    .then((response) => response.json())
+    .then((data) => {
+      if (!data.results.bindings.length) {
+        return null;
+      }
+      const entityId = data.results.bindings[0].item.value.split("/").pop();
+      return entityId;
+    });
+}
+
+function fetchWikidataEntityByGbifId(gbifId) {
+  const url = "https://query.wikidata.org/sparql";
+  const query = `
+    SELECT ?item WHERE {
+      ?item wdt:P846 "${gbifId}" .
+    }`;
+
+  return fetch(url + "?format=json&query=" + encodeURIComponent(query))
+    .then((response) => response.json())
+    .then((data) => {
+      if (!data.results.bindings.length) {
+        return null;
+      }
+      const entityId = data.results.bindings[0].item.value.split("/").pop();
+      return entityId;
+    });
+}
+function fetchImageFromWikidata(entityId) {
+  if (!entityId) return;
+  // Step 2: Retrieve the entity data from Wikidata
+  const url = `https://www.wikidata.org/wiki/Special:EntityData/${entityId}.json`;
+  return fetch(url)
+    .then((response) => response.json())
+    .then((data) => {
+      // Extract the image filename
+      const entity = data.entities[entityId];
+      const claims = entity.claims || {};
+      const imageClaims = claims.P18 || [];
+
+      if (!imageClaims.length) {
+        return "No image found for this entity.";
+      }
+
+      // Get the filename from the first image claim
+      const imageFilename = imageClaims[0].mainsnak.datavalue.value;
+      // Step 3: Construct the URL to fetch the image from Wikimedia Commons
+      const imageUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imageFilename}`;
+      return [
+        new Media({
+          url: imageUrl,
+          source: "Wikidata",
+        }),
+      ];
+    });
+}
+
+function fetchWikidataImage(idTaxon, connector, wikidataEntryID = null) {
+  if (!idTaxon) throw new Error("No taxonId given !");
+
+  if (wikidataEntryID) {
+    return fetchImageFromWikidata(wikidataEntryID);
+  } else if (idTaxon) {
+    let fetchIDPromise = null;
+    switch (connector.referential) {
+      case TAXON_REFERENTIAL.GBIF:
+        fetchIDPromise = fetchWikidataEntityByGbifId(idTaxon);
+        break;
+      case TAXON_REFERENTIAL.TAXREF:
+        fetchIDPromise = fetchWikidataEntityByTaxrefId(idTaxon);
+        break;
+      default:
+        break;
+    }
+    if (!fetchIDPromise) return;
+
+    return fetchIDPromise.then((idWikidata) => {
+      if (idWikidata) return fetchImageFromWikidata(idWikidata);
+    });
+  }
+}
+
+class WikiDataImageSource extends MediaSource {
+  constructor() {
+    super("WikidataMediaSource");
+  }
+  fetchMedia(taxonID, connector) {
+    if (!this.isCompatible(connector)) {
+      throw new Error(
+        `Wikidata Image source is only compatible with the GBIF and a TAXREF referential based connector `
+      );
+    }
+    return fetchWikidataImage(taxonID, connector);
+  }
+  isCompatible(connector) {
+    if ([GBIF, TAXREF].includes(connector.referential)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export { WikiDataImageSource };

--- a/src/lib/media/Wikidata.js
+++ b/src/lib/media/Wikidata.js
@@ -1,5 +1,6 @@
 import { Media } from "../models";
 import { TAXON_REFERENTIAL } from "../taxonReferential";
+import { SOURCE_ } from "./media";
 import { MediaSource } from "./MediaSource";
 
 const { GBIF, TAXREF } = TAXON_REFERENTIAL;
@@ -95,9 +96,9 @@ function fetchWikidataImage(idTaxon, connector, wikidataEntryID = null) {
 
 class WikiDataImageSource extends MediaSource {
   constructor() {
-    super("WikidataMediaSource");
+    super("WikidataMediaSource", SOURCE_.WIKIDATA);
   }
-  fetchMedia(taxonID, connector) {
+  fetchPicture(taxonID, connector) {
     if (!this.isCompatible(connector)) {
       throw new Error(
         `Wikidata Image source is only compatible with the GBIF and a TAXREF referential based connector `

--- a/src/lib/media/Wikidata.js
+++ b/src/lib/media/Wikidata.js
@@ -55,11 +55,10 @@ function fetchImageFromWikidata(entityId) {
       if (!imageClaims.length) {
         return "No image found for this entity.";
       }
-
       // Get the filename from the first image claim
       const imageFilename = imageClaims[0].mainsnak.datavalue.value;
       // Step 3: Construct the URL to fetch the image from Wikimedia Commons
-      const imageUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imageFilename}`;
+      const imageUrl = `https://commons.wikimedia.org/w/thumb.php?width=500&f=${imageFilename}`;
       return [
         new Media({
           url: imageUrl,

--- a/src/lib/media/media.js
+++ b/src/lib/media/media.js
@@ -7,7 +7,7 @@ export const SOURCE_ = Object.freeze({
   GBIF: "gbif",
   TAXREF_ODATA: "taxref_odata",
   WIKIDATA: "wikidata",
-  CUSTOM: "custom",
+  // CUSTOM: "custom",
 });
 
 export function getMediaSource(id, params = {}) {
@@ -18,7 +18,7 @@ export function getMediaSource(id, params = {}) {
       return new TaxrefODATA(params);
     case SOURCE_.WIKIDATA:
       return new WikiDataImageSource(params);
-    case SOURCE_.CUSTOM:
-      return new UrlMediaSource(params);
+    // case SOURCE_.CUSTOM:
+    //   return new UrlMediaSource(params);
   }
 }

--- a/src/lib/media/media.js
+++ b/src/lib/media/media.js
@@ -1,0 +1,24 @@
+import { GBIFMediaSource } from "./Gbif";
+import { TaxrefODATA } from "./Taxref";
+import { UrlMediaSource } from "./UrlMediaSource";
+import { WikiDataImageSource } from "./Wikidata";
+
+export const SOURCE_ = Object.freeze({
+  GBIF: "gbif",
+  TAXREF_ODATA: "taxref_odata",
+  WIKIDATA: "wikidata",
+  CUSTOM: "custom",
+});
+
+export function getMediaSource(id, params = {}) {
+  switch (id) {
+    case SOURCE_.GBIF:
+      return new GBIFMediaSource(params);
+    case SOURCE_.TAXREF_ODATA:
+      return new TaxrefODATA(params);
+    case SOURCE_.WIKIDATA:
+      return new WikiDataImageSource(params);
+    case SOURCE_.CUSTOM:
+      return new UrlMediaSource(params);
+  }
+}

--- a/src/lib/parameterStore.js
+++ b/src/lib/parameterStore.js
@@ -4,8 +4,6 @@ import { useRoute, useRouter } from "vue-router";
 import { parse, stringify } from "wellknown";
 import { buffer } from "@turf/turf";
 import { useI18n } from "vue-i18n";
-import { getBaseUrl } from "./utils";
-import { taxonClassIcons } from "@/assets/taxonclass2icon";
 
 class ParameterStore {
   static instance = null;

--- a/src/lib/parameterStore.js
+++ b/src/lib/parameterStore.js
@@ -117,8 +117,9 @@ class ParameterStore {
       .forEach(([key, value]) => {
         params[key] = value.value;
       });
+
     params["connector"] = this.connector.value.name;
-    params = { ...params, ...this.connector.value.options };
+    params = { ...params, ...this.connector.value.getParams() };
 
     if (params?.sourceGeometry != null && params?.wkt) {
       delete params["wkt"];

--- a/src/lib/parameterStore.js
+++ b/src/lib/parameterStore.js
@@ -4,6 +4,8 @@ import { useRoute, useRouter } from "vue-router";
 import { parse, stringify } from "wellknown";
 import { buffer } from "@turf/turf";
 import { useI18n } from "vue-i18n";
+import { getBaseUrl } from "./utils";
+import { taxonClassIcons } from "@/assets/taxonclass2icon";
 
 class ParameterStore {
   static instance = null;

--- a/src/lib/parameterStore.js
+++ b/src/lib/parameterStore.js
@@ -1,4 +1,4 @@
-import { ref, watch } from "vue";
+import { reactive, ref, watch } from "vue";
 import { getConnector } from "./connectors/utils";
 import { useRoute, useRouter } from "vue-router";
 import { parse, stringify } from "wellknown";
@@ -22,7 +22,7 @@ class ParameterStore {
     this.wkt = ref("");
     this.dateMin = ref(null);
     this.dateMax = ref(null);
-    this.connector = ref(getConnector(null, {}));
+    this.connector = reactive(getConnector(null, paramsFromUrl));
     this.itemsPerPage = ref(10);
     this.nbTaxonPerLine = ref(null);
     this.showFilters = ref(true);
@@ -35,7 +35,7 @@ class ParameterStore {
 
     ParameterStore.instance = this;
 
-    "radius wkt dateMin dateMax itemsPerPage nbTaxonPerLine showFilters lang mode class"
+    "radius wkt dateMin dateMax itemsPerPage nbTaxonPerLine showFilters lang mode class connector"
       .split(" ")
       .forEach((param) => {
         watch(this[param], () => {
@@ -75,7 +75,7 @@ class ParameterStore {
       getConnector(value, { ...paramsFromUrl })
     );
     this.setParameterFromUrl("class", (value) =>
-      Object.keys(this.connector.value.taxonClass2SourceID)?.includes(value)
+      Object.keys(this.connector.taxonClass2SourceID)?.includes(value)
         ? value
         : null
     );
@@ -116,8 +116,8 @@ class ParameterStore {
         params[key] = value.value;
       });
 
-    params["connector"] = this.connector.value.name;
-    params = { ...params, ...this.connector.value.getParams() };
+    params["connector"] = this.connector.name;
+    params = { ...params, ...this.connector.getParams() };
 
     if (params?.sourceGeometry != null && params?.wkt) {
       delete params["wkt"];

--- a/src/lib/parameterStore.js
+++ b/src/lib/parameterStore.js
@@ -115,7 +115,6 @@ class ParameterStore {
       .forEach(([key, value]) => {
         params[key] = value.value;
       });
-
     params["connector"] = this.connector.name;
     params = { ...params, ...this.connector.getParams() };
 

--- a/src/lib/taxonReferential.js
+++ b/src/lib/taxonReferential.js
@@ -1,0 +1,6 @@
+const TAXON_REFERENTIAL = Object.freeze({
+  GBIF: "GBIF",
+  TAXREF: "TAXREF",
+});
+
+export { TAXON_REFERENTIAL };


### PR DESCRIPTION
This PR allows users now to select different media source to (mainly) used to fetch picture displayed in the widget.

1. **Addition of Media Source Selection:**
   - Now users can select different media sources for taxa.
     - a new component `MediaSourceSelector.vue`

2. **Modifications to Existing Components:**
   - Pagination in `TaxonList.vue` is removed and an infinite scrolling is implemented

3. **Enhanced Media Management:**
   - Refactorisation of the logic for fetching media in connectors to use specific media sources. New classes were designed to handle media sources, including `GBIFMediaSource`, `TaxrefODATA`, and `WikiDataImageSource`.
   - Methods are available to check the compatibility of media sources with connectors. Mainly based on the taxon referential used by the connector
