### PR TITLE
Use facets in the GBIF connector

### DIFF
--- a/src/assets/languageAssets/cs.js
+++ b/src/assets/languageAssets/cs.js
@@ -88,6 +88,12 @@ Výsledky můžete také **sdílet 📤** a spolupracovat s ostatními uživatel
             apiEndpoint: 'API endpoint GBIF',
             howToContribute:
                 "Pokud chcete přispět k otevřeným datům pozorování biodiverzity agregovaným v GBIF, můžete využít kolaborativní platformy jako <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl{'@'}ntNet</a> nebo <a target='_blank' href='https://observation.org/'>Observation.org</a>.",
+            progress: {
+                fetching: 'Načítání pozorování...',
+                processing: 'Zpracování dat...',
+                enriching: 'Získávání informací o taxonech...',
+                finalizing: 'Dokončování...',
+            },
         },
         geonature: {
             api_endpoint: 'API endpoint GeoNature',

--- a/src/assets/languageAssets/de.js
+++ b/src/assets/languageAssets/de.js
@@ -88,6 +88,12 @@ Sie können Ihre Ergebnisse außerdem **teilen 📤**, um mit anderen Nutzern zu
             apiEndpoint: 'API-Adresse von GBIF',
             howToContribute:
                 "Wenn Sie zu den offenen Biodiversitätsbeobachtungsdaten beitragen möchten, die im GBIF aggregiert sind, können Sie kollaborative Plattformen wie <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl{'@'}ntNet</a> oder <a target='_blank' href='https://observation.org/'>Observation.org</a> nutzen.",
+            progress: {
+                fetching: 'Beobachtungen abrufen...',
+                processing: 'Daten verarbeiten...',
+                enriching: 'Taxon-Informationen abrufen...',
+                finalizing: 'Abschließen...',
+            },
         },
         geonature: {
             api_endpoint: 'API-Adresse von GeoNature',

--- a/src/assets/languageAssets/en.js
+++ b/src/assets/languageAssets/en.js
@@ -89,6 +89,12 @@ You can also **share your results 📤** to collaborate with other users.
             apiEndpoint: 'API endpoint of the GBIF',
             howToContribute:
                 "If you would like to contribute to the open biodiversity observation data aggregated in GBIF, you can use collaborative platforms such as <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl{'@'}ntNet</a> or <a target='_blank' href='https://observation.org/'>Observation.org</a>.",
+            progress: {
+                fetching: 'Fetching observations...',
+                processing: 'Processing data...',
+                enriching: 'Retrieving latest taxon information...',
+                finalizing: 'Finalizing...',
+            },
         },
         geonature: {
             api_endpoint: 'GeoNature  API endpoint',

--- a/src/assets/languageAssets/es.js
+++ b/src/assets/languageAssets/es.js
@@ -83,6 +83,12 @@ También puedes **compartir tus resultados 📤** para colaborar con otros usuar
             apiEndpoint: 'Punto final de la API de GBIF',
             howToContribute:
                 "Si desea contribuir a los datos abiertos de observaciones de biodiversidad agregados en GBIF, puede utilizar plataformas colaborativas como <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl{'@'}ntNet</a> o <a target='_blank' href='https://observation.org/'>Observation.org</a>.",
+            progress: {
+                fetching: 'Recuperando observaciones...',
+                processing: 'Procesando datos...',
+                enriching: 'Recuperando información de taxones...',
+                finalizing: 'Finalizando...',
+            },
         },
         geonature: {
             api_endpoint: 'Dirección de la API de GeoNature',

--- a/src/assets/languageAssets/fr.js
+++ b/src/assets/languageAssets/fr.js
@@ -88,6 +88,12 @@ Vous pouvez également **partager vos résultats 📤** pour collaborer avec d'a
             apiEndpoint: "Adresse de l'API du GBIF",
             howToContribute:
                 "Si vous souhaitez contribuer aux données ouvertes d'observations de biodiversité agrégées dans le GBIF, vous pouvez utiliser des plateformes collaboratives comme <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl{'@'}ntNet</a> ou <a target='_blank' href='https://observation.org/'>Observation.org</a>.",
+            progress: {
+                fetching: 'Récupération des observations...',
+                processing: 'Traitement des données...',
+                enriching: 'Récupération des dernières infos sur les taxons...',
+                finalizing: 'Finalisation...',
+            },
         },
         geonature: {
             api_endpoint: "Adresse de l'API de GeoNature",

--- a/src/assets/languageAssets/it.js
+++ b/src/assets/languageAssets/it.js
@@ -89,6 +89,12 @@ Puoi anche **condividere i tuoi risultati 📤** per collaborare con altri utent
             apiEndpoint: 'Indirizzo API del GBIF',
             howToContribute:
                 "Se desideri contribuire ai dati aperti sulle osservazioni della biodiversità aggregati nel GBIF, puoi utilizzare piattaforme collaborative come <a target='_blank' href='https://www.inaturalist.org/'>iNaturalist</a>, <a target='_blank' href='https://plantnet.org/'>Pl@ntNet</a> o <a target='_blank' href='https://observation.org/'>Observation.org</a>.",
+            progress: {
+                fetching: 'Recupero delle osservazioni...',
+                processing: 'Elaborazione dei dati...',
+                enriching: 'Recupero delle informazioni sui taxon...',
+                finalizing: 'Finalizzazione...',
+            },
         },
         geonature: {
             api_endpoint: 'Indirizzo API di GeoNature',

--- a/src/components/commons/ProgressBar.vue
+++ b/src/components/commons/ProgressBar.vue
@@ -1,0 +1,120 @@
+<script setup>
+    import { ref, watch, computed } from 'vue';
+    import ParameterStore from '@/lib/parameterStore';
+
+    const { primaryColor } = ParameterStore.getInstance();
+
+    const props = defineProps({
+        progress: {
+            type: Number,
+            default: 0,
+            validator: (value) => value >= 0 && value <= 100,
+        },
+        message: {
+            type: String,
+            default: '',
+        },
+    });
+
+    const currentProgress = ref(props.progress);
+
+    watch(
+        () => props.progress,
+        (newVal) => {
+            currentProgress.value = newVal;
+        }
+    );
+
+    const progressWidth = computed(() => `${currentProgress.value}%`);
+    const primaryColorHex = computed(() =>
+        primaryColor.value ? `#${primaryColor.value}` : '#444444'
+    );
+</script>
+
+<template>
+    <div class="progress-container" data-testid="ProgressBar component">
+        <div class="progress-card">
+            <div class="progress-bar-wrapper">
+                <div class="progress-bar-background">
+                    <div
+                        class="progress-bar-fill"
+                        :style="{ width: progressWidth }"
+                    ></div>
+                </div>
+            </div>
+            <p v-if="message" class="progress-message">{{ message }}</p>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+    .progress-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 60px 0;
+    }
+
+    .progress-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background: #ffffff;
+        border-radius: 18px;
+        box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
+        padding: 30px 50px;
+        transition: all 0.3s ease;
+        min-width: 320px;
+        max-width: 500px;
+    }
+
+    .progress-bar-wrapper {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .progress-bar-background {
+        width: 100%;
+        height: 24px;
+        background: linear-gradient(to right, #f0f0f0, #e8e8e8);
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+        position: relative;
+    }
+
+    .progress-bar-fill {
+        height: 100%;
+        background: v-bind(primaryColorHex);
+        border-radius: 12px;
+        transition: width 0.3s ease;
+        box-shadow: 0 2px 8px v-bind('primaryColorHex + "4D"');
+        position: relative;
+    }
+
+    .progress-message {
+        margin-top: 16px;
+        margin-bottom: 0;
+        font-size: 1rem;
+        font-weight: 500;
+        color: #666;
+        text-align: center;
+        letter-spacing: 0.3px;
+    }
+
+    @media (max-width: 576px) {
+        .progress-card {
+            min-width: 280px;
+            padding: 25px 35px;
+        }
+
+        .progress-percentage {
+            font-size: 1rem;
+        }
+
+        .progress-message {
+            font-size: 0.9rem;
+        }
+    }
+</style>

--- a/src/components/core/filters/SourceFilter.vue
+++ b/src/components/core/filters/SourceFilter.vue
@@ -5,6 +5,7 @@
     import { getConnector } from '@/lib/connectors/utils';
     import { GeoNatureConnector } from '@/lib/connectors/geonature';
     import { GbifConnector } from '@/lib/connectors/gbif';
+    import { GbifFacetConnector } from '@/lib/connectors/gbiffacet';
     import { CONNECTORS } from '@/lib/connectors/connectors';
 
     const props = defineProps({
@@ -19,6 +20,7 @@
     const sourcesParams = {
         [CONNECTORS.GBIF]: new GbifConnector().getParamsSchema(),
         [CONNECTORS.GeoNature]: new GeoNatureConnector().getParamsSchema(),
+        [CONNECTORS.GBIF_FACET]: new GbifFacetConnector().getParamsSchema(),
     };
 
     const sourceName = ref(connector.value.name);

--- a/src/components/core/taxonList/TaxonDetailed.vue
+++ b/src/components/core/taxonList/TaxonDetailed.vue
@@ -23,10 +23,10 @@
                 :media="props.picture"
                 :alt="props.picture?.urlSource"
             >
-                <img
-                    :src="props.picture?.url"
+                <Image
+                    :imageUrl="props.picture?.url"
                     :alt="props.picture?.urlSource"
-                    data-testid="Taxon picture"
+                    testID="Taxon picture"
                 />
             </FullScreenImage>
             <AudioPlayer
@@ -45,7 +45,7 @@
         <div class="names">
             <div class="vernacular-name">
                 <StatusIcon
-                    v-if="props.status.status"
+                    v-if="props.status?.status"
                     :status="props.status.status"
                     :color="props.status.color"
                     :size="'1.2rem'"
@@ -122,18 +122,27 @@
         bottom: 10px;
         right: 10px;
         z-index: 2;
+        width: auto;
     }
 
-    img {
-        display: block;
+    .audio-overlay {
+        width: auto;
+    }
+
+    .image-container > :not(.audio-overlay):not(.copyright-overlay) {
         width: 100%;
-        height: auto;
-        aspect-ratio: 1;
-        object-fit: cover;
+    }
+
+    :deep(.image-wrapper) {
         border-radius: 10px 10px 0px 0px;
         -webkit-border-radius: 10px 10px 0px 0px;
         -moz-border-radius: 10px 10px 0px 0px;
-        margin: 0 auto;
+    }
+
+    :deep(.image-wrapper img) {
+        border-radius: 10px 10px 0px 0px;
+        -webkit-border-radius: 10px 10px 0px 0px;
+        -moz-border-radius: 10px 10px 0px 0px;
     }
 
     .statistics-wrapper {

--- a/src/components/core/taxonList/TaxonList.vue
+++ b/src/components/core/taxonList/TaxonList.vue
@@ -81,6 +81,8 @@
         pageIndex,
         loadingObservations,
         loadingError,
+        loadingProgress,
+        loadingMessage,
     } = taxonManager;
 
     const speciesList = computed(() => searchResult.value.taxons);
@@ -168,6 +170,8 @@
                     <TaxonListMessages
                         :loading-error="loadingError"
                         :loading-observations="loadingObservations"
+                        :loading-progress="loadingProgress"
+                        :loading-message="loadingMessage"
                         :species-list="speciesList"
                         :filter-species-list="filteredSpecies"
                     />

--- a/src/components/core/taxonList/TaxonListMessages.vue
+++ b/src/components/core/taxonList/TaxonListMessages.vue
@@ -1,6 +1,7 @@
 <script setup>
     import { computed } from 'vue';
     import Loading from '@/components/commons/Loading.vue';
+    import ProgressBar from '@/components/commons/ProgressBar.vue';
     import ParameterStore from '@/lib/parameterStore';
 
     const parameterStore = ParameterStore.getInstance();
@@ -13,6 +14,14 @@
         loadingError: {
             type: Boolean,
         },
+        loadingProgress: {
+            type: Number,
+            default: 0,
+        },
+        loadingMessage: {
+            type: String,
+            default: '',
+        },
         speciesList: {
             type: Array,
         },
@@ -20,6 +29,16 @@
             type: Array,
         },
     });
+
+    // Determine if we should show progress bar or simple loading spinner
+    const showProgressBar = computed(
+        () => props.loadingObservations && props.loadingProgress > 0
+    );
+
+    const showLoading = computed(
+        () => props.loadingObservations && props.loadingProgress === 0
+    );
+
     // Calcul des états pour l'affichage des messages
     const noGeometry = computed(
         () =>
@@ -46,9 +65,19 @@
 
 <template>
     <div class="message">
+        <!-- Progress bar for connectors with progress reporting -->
+        <ProgressBar
+            v-if="showProgressBar"
+            :progress="props.loadingProgress"
+            :message="props.loadingMessage"
+            class="message-box"
+        />
+
+        <!-- Simple loading spinner for connectors without progress -->
         <Loading
+            v-if="showLoading"
             id="loadingObs"
-            :loadingStatus="props.loadingObservations"
+            :loadingStatus="true"
             class="message-box"
         />
 

--- a/src/components/core/taxonList/TaxonThumbnail.vue
+++ b/src/components/core/taxonList/TaxonThumbnail.vue
@@ -47,7 +47,7 @@
             <div class="card-img-overlay">
                 <div class="card-title">
                     <StatusIcon
-                        v-if="props.status.status"
+                        v-if="props.status?.status"
                         :status="props.status.status"
                         :color="props.status.color"
                         :size="'1rem'"

--- a/src/components/core/taxonList/TaxonView.vue
+++ b/src/components/core/taxonList/TaxonView.vue
@@ -130,12 +130,19 @@
     }
 
     function fetchStatus(connector: Connector) {
-        connector.fetchTaxonStatus(taxon.taxonId).then((status_) => {
-            status.value = {
-                status: status_,
-                color: connector.getStatusColor(status_),
-            };
-        });
+        connector
+            .fetchTaxonStatus(taxon.taxonId)
+            .then((status_) => {
+                if (status_) {
+                    status.value = {
+                        status: status_,
+                        color: connector.getStatusColor(status_),
+                    };
+                }
+            })
+            .catch((err) => {
+                console.warn('Failed to fetch taxon status:', err);
+            });
     }
 
     fetchTaxonImage();

--- a/src/components/core/taxonList/TaxonView.vue
+++ b/src/components/core/taxonList/TaxonView.vue
@@ -62,10 +62,10 @@
     });
 
     function refreshVernacularName() {
+        if (taxon.vernacularName) return;
         connector.value.fetchVernacularName(taxon.taxonId).then((name) => {
             if (name) {
-                vernacularName.value = name.split(',')[0];
-                taxon.vernacularName = vernacularName.value;
+                taxon.vernacularName = name.split(',')[0];
             }
         });
     }
@@ -94,7 +94,7 @@
         v-if="mode == 'gallery'"
         :picture="mediaDisplayed"
         :audio="speciesAudio"
-        :vernacular-name="vernacularName || taxon.acceptedScientificName"
+        :vernacular-name="taxon.vernacularName || taxon.acceptedScientificName"
         :url-detail-page="fetchDetailUrl(taxon.taxonId)"
         :accepted-scientific-name="taxon.acceptedScientificName"
         :cols="props.cols"
@@ -106,7 +106,7 @@
         :picture="mediaDisplayed"
         :audio="speciesAudio"
         :accepted-scientific-name="taxon.acceptedScientificName"
-        :vernacular-name="vernacularName || taxon.acceptedScientificName"
+        :vernacular-name="taxon.vernacularName || taxon.acceptedScientificName"
         :url-detail-page="fetchDetailUrl(taxon.taxonId)"
         :nb-observations="taxon?.nbObservations"
         :last-seen-date="taxon?.lastSeenDate"

--- a/src/components/core/taxonList/TaxonView.vue
+++ b/src/components/core/taxonList/TaxonView.vue
@@ -34,7 +34,14 @@
 
     function fetchTaxonImage() {
         speciesPhoto.value = [];
-        if (taxon.taxonId) {
+        if (taxon.mediaUrl) {
+            speciesPhoto.value = [
+                {
+                    url: taxon.mediaUrl,
+                    typeMedia: MediaType.image,
+                },
+            ];
+        } else if (taxon.taxonId) {
             connector.value.imageSource
                 .fetchPicture(taxon.taxonId, connector.value)
                 .then((response) => {
@@ -62,7 +69,10 @@
     });
 
     function refreshVernacularName() {
-        if (taxon.vernacularName) return;
+        if (taxon.vernacularName) {
+            console.log('Vernacular name already exists, no need to fetch it');
+            return;
+        }
         connector.value.fetchVernacularName(taxon.taxonId).then((name) => {
             if (name) {
                 taxon.vernacularName = name.split(',')[0];

--- a/src/components/core/taxonList/TaxonView.vue
+++ b/src/components/core/taxonList/TaxonView.vue
@@ -34,6 +34,40 @@
 
     function fetchTaxonImage() {
         speciesPhoto.value = [];
+
+        // First priority: use medias array if available
+        if (taxon.medias && taxon.medias.length > 0) {
+            const images = taxon.medias.filter(
+                (m) => m.typeMedia === MediaType.image
+            );
+            if (images.length > 0) {
+                speciesPhoto.value = [...images];
+
+                // For detailed view, fetch full credits if not already present
+                images.forEach((media, index) => {
+                    // Check if media already has full credits (has license field)
+                    if (!media.license && media.source) {
+                        // Use the media source's getCredits method to fetch full credits
+                        connector.value.imageSource
+                            .getCredits(media)
+                            .then((enrichedMedia) => {
+                                // Update the media with full credits
+                                speciesPhoto.value[index] = enrichedMedia;
+                            })
+                            .catch((err) => {
+                                console.warn(
+                                    `Failed to fetch credits for ${media.source}:`,
+                                    err
+                                );
+                            });
+                    }
+                });
+
+                return;
+            }
+        }
+
+        // Second priority: use mediaUrl for backward compatibility
         if (taxon.mediaUrl) {
             speciesPhoto.value = [
                 {
@@ -41,7 +75,9 @@
                     typeMedia: MediaType.image,
                 },
             ];
-        } else if (taxon.taxonId) {
+        }
+        // Last resort: fetch from media source
+        else if (taxon.taxonId) {
             connector.value.imageSource
                 .fetchPicture(taxon.taxonId, connector.value)
                 .then((response) => {
@@ -51,6 +87,19 @@
     }
     function fetchTaxonAudio() {
         speciesAudio.value = null;
+
+        // First priority: use medias array if available (includes full credits)
+        if (taxon.medias && taxon.medias.length > 0) {
+            const sounds = taxon.medias.filter(
+                (m) => m.typeMedia === MediaType.sound
+            );
+            if (sounds.length > 0) {
+                speciesAudio.value = sounds[0];
+                return;
+            }
+        }
+
+        // Fallback: fetch from media source
         if (taxon.taxonId) {
             connector.value.soundSource
                 .fetchSound(taxon.taxonId, connector.value)

--- a/src/components/core/taxonList/taxonListManager.ts
+++ b/src/components/core/taxonList/taxonListManager.ts
@@ -62,6 +62,16 @@ export class TaxonListManager {
      */
     public loadingError: Ref<boolean> = ref(false);
     /**
+     * The current loading progress (0-100)
+     * @type {Ref<number>}
+     */
+    public loadingProgress: Ref<number> = ref(0);
+    /**
+     * The current loading message
+     * @type {Ref<string>}
+     */
+    public loadingMessage: Ref<string> = ref('');
+    /**
      * A computed property that returns the species list to be displayed
      * @type {any}
      */
@@ -113,7 +123,18 @@ export class TaxonListManager {
 
         this.loadingObservations.value = true;
         this.loadingError.value = false;
+        this.loadingProgress.value = 0;
+        this.loadingMessage.value = '';
         this.filteredSpecies.value = [];
+
+        // Configure progress callback
+        this.connector.value.onProgress = (
+            progress: number,
+            message?: string
+        ) => {
+            this.loadingProgress.value = progress;
+            this.loadingMessage.value = message || '';
+        };
 
         this.connector.value
             .fetchOccurrence({
@@ -127,10 +148,14 @@ export class TaxonListManager {
                 this.filteredSpecies.value = response.taxons;
                 this.pageIndex.value = 0;
                 this.loadingObservations.value = false;
+                this.loadingProgress.value = 0;
+                this.loadingMessage.value = '';
             })
             .catch(() => {
                 this.loadingError.value = true;
                 this.loadingObservations.value = false;
+                this.loadingProgress.value = 0;
+                this.loadingMessage.value = '';
             });
     }
 

--- a/src/lib/connectors/connector.ts
+++ b/src/lib/connectors/connector.ts
@@ -62,11 +62,28 @@ export class Connector {
      */
     scoringSearchClass: SearchScoring = new SearchScoring();
 
+    /**
+     * Optional callback function to report progress during long-running operations
+     * @type {Function}
+     */
+    onProgress?: (progress: number, message?: string) => void;
+
     constructor(options: ConnectorOptions) {
         this.options = options;
 
         this.imageSource = this.parseMediaSource(options?.imageSource);
         this.soundSource = this.parseMediaSource(options?.soundSource);
+    }
+
+    /**
+     * Helper method to report progress if a callback is configured
+     * @param {number} progress - Progress percentage (0-100)
+     * @param {string} message - Optional message to display
+     */
+    protected reportProgress(progress: number, message?: string): void {
+        if (this.onProgress) {
+            this.onProgress(progress, message);
+        }
     }
 
     /**

--- a/src/lib/connectors/connector.ts
+++ b/src/lib/connectors/connector.ts
@@ -254,7 +254,7 @@ export class Connector {
      * @returns {Promise<string>} A promise that resolves to the conservation status of the taxon.
      */
     fetchTaxonStatus(taxonId: string | number): Promise<IUCNCodeStatus> {
-        return null;
+        return Promise.resolve(null);
     }
 
     /**

--- a/src/lib/connectors/connector.ts
+++ b/src/lib/connectors/connector.ts
@@ -265,6 +265,11 @@ export class Connector {
         return this.name;
     }
 
+    /**
+     * Returns the color associated with a given IUCN conservation status code.
+     * @param {IUCNCodeStatus} status - The IUCN conservation status code.
+     * @returns {string} The color associated with the given IUCN conservation status code.
+     */
     getStatusColor(status: IUCNCodeStatus): string {
         const IUCNStatusColorDICT = {
             NA: '#C1B5A5',

--- a/src/lib/connectors/connectors.ts
+++ b/src/lib/connectors/connectors.ts
@@ -1,4 +1,5 @@
 export enum CONNECTORS {
     GBIF = 'GBIF',
     GeoNature = 'GeoNature',
+    GBIF_FACET = 'GBIF_FACET',
 }

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -1,0 +1,380 @@
+import { Connector, ConnectorOptions } from './connector';
+import { Dataset, SearchResult, Taxon } from '../models';
+import ParameterStore from '../parameterStore';
+import { NO_IMAGE_URL } from '@/assets/constant';
+import { TAXON_REFERENTIAL } from '../taxonReferential';
+import { getMediaSource, SOURCE_ } from '../media/media';
+import { useI18n } from 'vue-i18n';
+import { CONNECTORS } from './connectors';
+import { GBIFSearchScoring } from './search/gbif';
+
+const GBIF_ENDPOINT_DEFAULT = 'https://api.gbif.org/v1';
+const GBIF_DEFAULT_TAXON_LIMIT = 1000;
+
+type OccurrenceParams = Record<string, any>;
+
+export class GbifFacetConnector extends Connector {
+    name: string;
+    GBIF_ENDPOINT: string;
+    LIMIT: number;
+
+    constructor(options: ConnectorOptions) {
+        super(options);
+        this.name = CONNECTORS.GBIF_FACET;
+
+        // specific parameters
+        this.GBIF_ENDPOINT =
+            this.options?.GBIF_ENDPOINT || GBIF_ENDPOINT_DEFAULT;
+        this.LIMIT = this.options?.LIMIT || GBIF_DEFAULT_TAXON_LIMIT;
+
+        this.referential = TAXON_REFERENTIAL.GBIF;
+
+        this.imageSource = this.imageSource || getMediaSource(SOURCE_.wikidata);
+        this.soundSource = this.soundSource || getMediaSource(SOURCE_.wikidata);
+
+        this.taxonClass2SourceID = {
+            Aves: 212,
+            Mammalia: 359,
+            Reptilia: 358,
+            Amphibia: 131,
+            Insecta: 216,
+            Arachnida: 367,
+            Gastropoda: 225,
+            Bivalvia: 137,
+            Magnoliopsida: 220,
+            Liliopsida: 196,
+            Pinopsida: 194,
+        };
+        this.isSearchOnAPIAvailable = true;
+        this.scoringSearchClass = new GBIFSearchScoring();
+    }
+
+    getParamsSchema(): Array<Record<string, any>> {
+        const { t } = useI18n();
+        return [
+            {
+                name: 'GBIF_ENDPOINT',
+                label: "Adresse de l'API du GBIF",
+                type: String,
+                default: 'https://api.gbif.org/v1',
+            },
+            {
+                name: 'LIMIT',
+                label: t('limit'),
+                type: Number,
+                default: GBIF_DEFAULT_TAXON_LIMIT,
+            },
+        ];
+    }
+
+    fetchVernacularName(taxonID: string | number): Promise<string | undefined> {
+        const mapping_language: Record<string, string> = {
+            en: 'eng',
+            fr: 'fra',
+            es: 'spa',
+            cs: 'ces',
+            it: 'ita',
+            de: 'deu',
+        };
+        const currentLanguage = ParameterStore.getInstance().lang.value;
+        return fetch(
+            `${this.GBIF_ENDPOINT}/species/${taxonID}/vernacularNames?limit=100`
+        )
+            .then((response) => response.json())
+            .then((data) => {
+                const nameData = data.results.find(
+                    (nameData: any) =>
+                        nameData.language === mapping_language[currentLanguage]
+                );
+                return nameData
+                    ? nameData.vernacularName.charAt(0).toUpperCase() +
+                          nameData.vernacularName.slice(1)
+                    : undefined;
+            });
+    }
+
+    fetchOccurrence(params: any = {}): Promise<SearchResult> {
+        super.fetchOccurrence(params);
+
+        const searchParams = this.buildSearchParams(params);
+        const urlWithParams = this.buildSearchUrl(searchParams);
+
+        return fetch(urlWithParams.toString())
+            .then((response) => response.json())
+            .then(async (data) => {
+                const taxonsData: Record<string, Taxon> = {};
+                const datasetData: Record<string, Dataset> = {};
+
+                if (data.facets && data.facets.length > 0) {
+                    await this.processTaxonFacets(data.facets, taxonsData);
+                    this.processDatasetFacets(data.facets, datasetData);
+                }
+
+                return {
+                    taxons: Object.values(taxonsData),
+                    datasets: Object.values(datasetData),
+                };
+            });
+    }
+
+    /**
+     * Builds search parameters for the GBIF API.
+     * Merges default parameters with user-provided ones.
+     * Handles date transformation and taxonomic class mapping.
+     *
+     * @param params - Custom search parameters
+     * @returns Formatted parameters for the GBIF API
+     */
+    private buildSearchParams(params: any): OccurrenceParams {
+        let searchParams = {
+            occurrenceStatus: 'PRESENT',
+            basisOfRecord: [
+                'OBSERVATION',
+                'HUMAN_OBSERVATION',
+                'MACHINE_OBSERVATION',
+                'OCCURRENCE',
+            ],
+            hasGeospatialIssue: false,
+            hasCoordinate: true,
+            facet: ['taxonKey', 'datasetKey'],
+            facetLimit: this.LIMIT,
+            limit: 0,
+            ...params,
+        };
+
+        // Gestion de la plage de dates
+        if (searchParams.dateMin && searchParams.dateMax) {
+            searchParams.eventDate = `${searchParams.dateMin},${searchParams.dateMax}`;
+            delete searchParams.dateMin;
+            delete searchParams.dateMax;
+        }
+
+        // Gestion de la classe taxonomique
+        if (params?.class) {
+            searchParams.classKey = this.taxonClass2SourceID[params.class];
+            delete searchParams.class;
+        }
+
+        return searchParams;
+    }
+
+    /**
+     * Builds the complete URL for the GBIF search query.
+     * Properly encodes simple parameters and arrays.
+     *
+     * @param params - Search parameters to encode in the URL
+     * @returns Complete URL with all parameters
+     */
+    private buildSearchUrl(params: OccurrenceParams): URL {
+        const url = new URL(`${this.GBIF_ENDPOINT}/occurrence/search`);
+
+        Object.entries(params).forEach(([key, value]) => {
+            if (Array.isArray(value)) {
+                value.forEach((item) => url.searchParams.append(key, item));
+            } else {
+                url.searchParams.append(key, value);
+            }
+        });
+
+        return url;
+    }
+
+    /**
+     * Processes taxon facets returned by the GBIF API.
+     * Retrieves detailed information for each taxon in parallel.
+     * Filters taxa based on their taxonomic rank.
+     *
+     * @param facets - List of facets returned by the API
+     * @param taxonsData - Object to store validated taxon data
+     */
+    private async processTaxonFacets(
+        facets: any[],
+        taxonsData: Record<string, Taxon>
+    ): Promise<void> {
+        const taxonFacet = facets.find((f: any) => f.field === 'TAXON_KEY');
+
+        if (!taxonFacet?.counts) {
+            return;
+        }
+
+        const taxonPromises = taxonFacet.counts.map((facetItem: any) =>
+            this.processSingleTaxon(facetItem, taxonsData)
+        );
+
+        await Promise.all(taxonPromises); // TODO : watch out for performance
+    }
+
+    /**
+     * Processes an individual taxon from the facet.
+     * Retrieves its information from the GBIF API and validates its taxonomic rank.
+     * If the rank is valid, adds the taxon to the collection.
+     *
+     * @param facetItem - Facet item containing the taxonKey and count
+     * @param taxonsData - Collection to add the taxon to if valid
+     */
+    private async processSingleTaxon(
+        facetItem: any,
+        taxonsData: Record<string, Taxon>
+    ): Promise<void> {
+        const taxonKey = facetItem.name;
+        const nbObservations = facetItem.count;
+
+        try {
+            const taxonInfo = await this.fetchTaxonInfo(taxonKey);
+
+            if (!this.isValidTaxonRank(taxonInfo.rank)) {
+                return;
+            }
+
+            taxonsData[taxonKey] = this.createTaxonObject(
+                taxonKey,
+                taxonInfo,
+                nbObservations
+            );
+        } catch (error) {
+            console.error(
+                `Erreur lors de la récupération du taxon ${taxonKey}:`,
+                error
+            );
+        }
+    }
+
+    /**
+     * Creates a standardized Taxon object from retrieved information.
+     *
+     * @param taxonKey - Unique identifier of the taxon in GBIF
+     * @param taxonInfo - Taxon information (scientific name, vernacular name, rank)
+     * @param nbObservations - Number of observations for this taxon
+     * @returns Formatted Taxon object
+     */
+    private createTaxonObject(
+        taxonKey: string,
+        taxonInfo: {
+            scientificName: string;
+            vernacularName: string;
+            rank: string;
+        },
+        nbObservations: number
+    ): Taxon {
+        return {
+            acceptedScientificName: taxonInfo.scientificName,
+            vernacularName: taxonInfo.vernacularName || '',
+            taxonId: taxonKey,
+            mediaUrl: NO_IMAGE_URL,
+            taxonRank: taxonInfo.rank,
+            kingdom: '',
+            class: '',
+            nbObservations: nbObservations,
+            description: '',
+            lastSeenDate: new Date(),
+        };
+    }
+
+    /**
+     * Processes dataset facets returned by the GBIF API.
+     * Extracts information from each dataset (UUID, number of observations).
+     *
+     * @param facets - List of facets returned by the API
+     * @param datasetData - Object to store dataset data
+     */
+    private processDatasetFacets(
+        facets: any[],
+        datasetData: Record<string, Dataset>
+    ): void {
+        const datasetFacet = facets.find((f: any) => f.field === 'DATASET_KEY');
+
+        if (!datasetFacet?.counts) {
+            return;
+        }
+
+        datasetFacet.counts.forEach((facetItem: any) => {
+            datasetData[facetItem.name] = {
+                uuid: facetItem.name,
+                name: facetItem.name,
+                nbObservations: facetItem.count,
+            };
+        });
+    }
+
+    /**
+     * Checks if a taxonomic rank is specific enough.
+     * Filters out ranks that are too high like family, order, class, etc.
+     *
+     * @param rank - Taxonomic rank to validate (e.g., 'SPECIES', 'GENUS', 'FAMILY')
+     * @returns true if the rank is accepted, false otherwise
+     */
+    private isValidTaxonRank(rank: string): boolean {
+        const acceptedRanks = ['SPECIES', 'SUBSPECIES'];
+        return acceptedRanks.includes(rank.toUpperCase());
+    }
+
+    fetchTaxonInfo(idTaxon: string): Promise<{
+        scientificName: string;
+        vernacularName: string;
+        rank: string;
+        taxonKey: number;
+    }> {
+        const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}`;
+        return fetch(url)
+            .then((response) => response.json())
+            .then((json) => ({
+                scientificName: json.scientificName,
+                vernacularName: json.vernacularName,
+                rank: json.rank,
+                taxonKey: json.key,
+            }));
+    }
+
+    fetchTaxonStatus(idTaxon: string): Promise<{
+        iucnRedListCategory: string;
+        code: string;
+    }> {
+        const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}/iucnRedListCategory`;
+        return fetch(url)
+            .then((response) => response.json())
+            .then((json) => ({
+                iucnRedListCategory: json.category,
+                code: json.code,
+            }));
+    }
+
+    searchTaxon(
+        searchString: string = '',
+        params: OccurrenceParams = {}
+    ): Promise<Array<{ scientificName: string; taxonKey: number }>> {
+        const url = `${this.GBIF_ENDPOINT}/species/search?q=${searchString}&limit=20`;
+        return fetch(url)
+            .then((response) => response.json())
+            .then((json) =>
+                json.results.map((element: any) => ({
+                    scientificName: element.scientificName,
+                    taxonKey: element.key,
+                }))
+            );
+    }
+
+    getTaxonDetailPage(taxonId: string): string {
+        return `https://www.gbif.org/species/${taxonId}`;
+    }
+
+    sourceDetailMessage(): string {
+        return useI18n().t('source.gbifWarning', {
+            nbObs: GBIF_DEFAULT_TAXON_LIMIT,
+        });
+    }
+    getSourceUrl(): string | null {
+        return 'https://www.gbif.org';
+    }
+
+    getDatasetUrl(datasetID: any): string | null {
+        return `${this.getSourceUrl()}/dataset/${datasetID}`;
+    }
+
+    searchOnAPI(searchString: string): Promise<any> {
+        return fetch(
+            `${this.GBIF_ENDPOINT}/species/search?q=${searchString}&status=ACCEPTED&qField=VERNACULAR&limit=100`
+        )
+            .then((response) => response.json())
+            .then((json) => json.results);
+    }
+}

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -266,7 +266,7 @@ export class GbifFacetConnector extends Connector {
             class: '',
             nbObservations: nbObservations,
             description: '',
-            lastSeenDate: new Date(),
+            // lastSeenDate: new Date(),
         };
     }
 

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -7,44 +7,95 @@ import { getMediaSource, SOURCE_ } from '../media/media';
 import { useI18n } from 'vue-i18n';
 import { CONNECTORS } from './connectors';
 import { GBIFSearchScoring } from './search/gbif';
+import { removeHoles } from './utils';
+import { parse, stringify } from 'wellknown';
+import { fetchJson } from '../utils';
 
 const GBIF_ENDPOINT_DEFAULT = 'https://api.gbif.org/v1';
 const GBIF_DEFAULT_TAXON_LIMIT = 1000;
+const WIKIDATA_SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+const INAT_API_ENDPOINT = 'https://api.inaturalist.org/v1/taxa';
+const INAT_BATCH_SIZE = 30;
 
 type OccurrenceParams = Record<string, any>;
+
+interface TaxonWithAncestors extends Taxon {
+    ancestors?: Array<{ id: number; name: string; rank: string }>;
+    iconicTaxonName?: string;
+    iNatId?: string;
+}
+
+interface WikidataBinding {
+    gbifID: { value: string };
+    iNatID?: { value: string };
+    scientificName?: { value: string };
+    commonName?: { value: string }; // nouveau
+    image?: { value: string };
+}
+
+interface EnrichedTaxonData {
+    scientificName?: string;
+    commonName?: string;
+    photo?: string;
+    iNatId?: string;
+    ancestors?: any[];
+    kingdom?: string;
+    phylum?: string;
+    order?: string;
+    family?: string;
+    genus?: string;
+    iconicTaxonName?: string;
+}
+
+function buildUrl(base: string, params: Record<string, any>): string {
+    const url = new URL(base);
+    Object.entries(params).forEach(([key, value]) => {
+        if (Array.isArray(value)) {
+            value.forEach((v) => url.searchParams.append(key, v));
+        } else if (value !== undefined && value !== null) {
+            url.searchParams.append(key, value);
+        }
+    });
+    return url.toString();
+}
+
+function callOccurrenceApi(params: OccurrenceParams = {}): Promise<any> {
+    return fetchJson<any>(
+        buildUrl(`${GBIF_ENDPOINT_DEFAULT}/occurrence/search`, params)
+    );
+}
 
 export class GbifFacetConnector extends Connector {
     name: string;
     GBIF_ENDPOINT: string;
     LIMIT: number;
+    NB_PAGES: number = 1;
+    private enrichTaxonomyCache: Map<string, EnrichedTaxonData> = new Map();
+
+    taxonClass2SourceID = {
+        Aves: 212,
+        Mammalia: 359,
+        Reptilia: 358,
+        Amphibia: 131,
+        Insecta: 216,
+        Arachnida: 367,
+        Gastropoda: 225,
+        Bivalvia: 137,
+        Magnoliopsida: 220,
+        Liliopsida: 196,
+        Pinopsida: 194,
+    };
 
     constructor(options: ConnectorOptions) {
         super(options);
         this.name = CONNECTORS.GBIF_FACET;
-
-        // specific parameters
-        this.GBIF_ENDPOINT =
-            this.options?.GBIF_ENDPOINT || GBIF_ENDPOINT_DEFAULT;
-        this.LIMIT = this.options?.LIMIT || GBIF_DEFAULT_TAXON_LIMIT;
+        this.GBIF_ENDPOINT = options?.GBIF_ENDPOINT || GBIF_ENDPOINT_DEFAULT;
+        this.LIMIT = options?.LIMIT || GBIF_DEFAULT_TAXON_LIMIT;
 
         this.referential = TAXON_REFERENTIAL.GBIF;
-
         this.imageSource = this.imageSource || getMediaSource(SOURCE_.wikidata);
         this.soundSource = this.soundSource || getMediaSource(SOURCE_.wikidata);
 
-        this.taxonClass2SourceID = {
-            Aves: 212,
-            Mammalia: 359,
-            Reptilia: 358,
-            Amphibia: 131,
-            Insecta: 216,
-            Arachnida: 367,
-            Gastropoda: 225,
-            Bivalvia: 137,
-            Magnoliopsida: 220,
-            Liliopsida: 196,
-            Pinopsida: 194,
-        };
         this.isSearchOnAPIAvailable = true;
         this.scoringSearchClass = new GBIFSearchScoring();
     }
@@ -56,7 +107,7 @@ export class GbifFacetConnector extends Connector {
                 name: 'GBIF_ENDPOINT',
                 label: "Adresse de l'API du GBIF",
                 type: String,
-                default: 'https://api.gbif.org/v1',
+                default: GBIF_ENDPOINT_DEFAULT,
             },
             {
                 name: 'LIMIT',
@@ -77,56 +128,147 @@ export class GbifFacetConnector extends Connector {
             de: 'deu',
         };
         const currentLanguage = ParameterStore.getInstance().lang.value;
-        return fetch(
+
+        return fetchJson(
             `${this.GBIF_ENDPOINT}/species/${taxonID}/vernacularNames?limit=100`
-        )
-            .then((response) => response.json())
-            .then((data) => {
-                const nameData = data.results.find(
-                    (nameData: any) =>
-                        nameData.language === mapping_language[currentLanguage]
-                );
-                return nameData
-                    ? nameData.vernacularName.charAt(0).toUpperCase() +
-                          nameData.vernacularName.slice(1)
-                    : undefined;
-            });
+        ).then((data) => {
+            const match = data.results.find(
+                (r: any) => r.language === mapping_language[currentLanguage]
+            );
+            return match
+                ? match.vernacularName.charAt(0).toUpperCase() +
+                      match.vernacularName.slice(1)
+                : undefined;
+        });
     }
 
+    private buildWikidataSparql(gbifIds: string[], lang: string): string {
+        const values = gbifIds.map((id) => `"${id}"`).join(' ');
+        return `
+        SELECT ?gbifID ?iNatID ?scientificName ?commonName ?image
+        WHERE {
+            VALUES ?gbifID { ${values} }
+            ?taxon wdt:P846 ?gbifID .
+            OPTIONAL { ?taxon wdt:P3151 ?iNatID . }
+            OPTIONAL { ?taxon wdt:P225 ?scientificName . }
+            OPTIONAL { ?taxon p:P1843 ?commonNameStatement .
+                       ?commonNameStatement ps:P1843 ?commonName .
+                       FILTER(LANG(?commonName) = "${lang}")
+            }
+            OPTIONAL { ?taxon wdt:P18 ?image . }
+        }
+    `;
+    }
+
+    private async enrichTaxonomy(
+        gbifIds: string[]
+    ): Promise<Map<string, EnrichedTaxonData>> {
+        const uncachedIds = gbifIds.filter(
+            (id) => !this.enrichTaxonomyCache.has(id)
+        );
+        if (!uncachedIds.length) return this.enrichTaxonomyCache;
+
+        const currentLang = ParameterStore.getInstance().lang.value;
+
+        try {
+            // Fetch all Wikidata IDs in a single POST
+            const sparql = this.buildWikidataSparql(uncachedIds, currentLang);
+            const wikidataResponse = await fetch(WIKIDATA_SPARQL_ENDPOINT, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    Accept: 'application/sparql-results+json',
+                },
+                body: new URLSearchParams({ query: sparql }),
+            });
+            if (!wikidataResponse.ok)
+                throw new Error(
+                    `Wikidata POST failed: ${wikidataResponse.status}`
+                );
+            const wikidataData = await wikidataResponse.json();
+
+            // Process Wikidata results
+            const gbifToINat: Record<string, string> = {};
+            wikidataData.results.bindings.forEach((b: WikidataBinding) => {
+                const gbifId = b.gbifID.value;
+                const existing = this.enrichTaxonomyCache.get(gbifId) || {};
+                this.enrichTaxonomyCache.set(gbifId, {
+                    ...existing,
+                    scientificName: b.scientificName?.value,
+                    commonName: b.commonName?.value.replace(/^./, (char) =>
+                        char.toUpperCase()
+                    ),
+                    photo: b.image?.value,
+                });
+                if (b.iNatID) gbifToINat[gbifId] = b.iNatID.value;
+            });
+
+            // iNaturalist
+            const iNatIds = Object.values(gbifToINat);
+            const iNatPromises: Promise<any>[] = [];
+            for (let i = 0; i < iNatIds.length; i += INAT_BATCH_SIZE) {
+                const batch = iNatIds.slice(i, i + INAT_BATCH_SIZE);
+                if (!batch.length) continue;
+                iNatPromises.push(
+                    fetchJson(`${INAT_API_ENDPOINT}/${batch.join(',')}`)
+                );
+            }
+
+            const iNatResults = await Promise.all(iNatPromises);
+
+            // Merge iNaturalist data into cache
+            iNatResults.forEach((iNatData) => {
+                Object.entries(gbifToINat).forEach(([gbifId, iNatId]) => {
+                    const taxon = iNatData.results.find(
+                        (t: any) => t.id == iNatId
+                    );
+                    if (!taxon) return;
+                    const existing = this.enrichTaxonomyCache.get(gbifId) || {};
+                    this.enrichTaxonomyCache.set(gbifId, {
+                        ...existing,
+                        iNatId,
+                        scientificName: taxon.name,
+                        commonName:
+                            existing.commonName || taxon.preferred_common_name,
+                        ancestors: taxon.ancestors || [],
+                        kingdom: taxon.ancestors?.find(
+                            (a: any) => a.rank === 'kingdom'
+                        )?.name,
+                        phylum: taxon.ancestors?.find(
+                            (a: any) => a.rank === 'phylum'
+                        )?.name,
+                        order: taxon.ancestors?.find(
+                            (a: any) => a.rank === 'order'
+                        )?.name,
+                        family: taxon.ancestors?.find(
+                            (a: any) => a.rank === 'family'
+                        )?.name,
+                        genus: taxon.ancestors?.find(
+                            (a: any) => a.rank === 'genus'
+                        )?.name,
+                        iconicTaxonName: taxon.iconic_taxon_name, // equivalent of the functional group in INPN
+                        photo:
+                            taxon.default_photo?.medium_url || existing.photo,
+                    });
+                });
+            });
+        } catch (e) {
+            console.error(`[${this.name}] enrichTaxonomy failed`, e);
+        }
+
+        return this.enrichTaxonomyCache;
+    }
+
+    /* ---------- fetchOccurrence ---------- */
     fetchOccurrence(params: any = {}): Promise<SearchResult> {
         super.fetchOccurrence(params);
+        if (params.geometry)
+            params.geometry = stringify(removeHoles(parse(params.geometry)));
 
-        const searchParams = this.buildSearchParams(params);
-        const urlWithParams = this.buildSearchUrl(searchParams);
-
-        return fetch(urlWithParams.toString())
-            .then((response) => response.json())
-            .then(async (data) => {
-                const taxonsData: Record<string, Taxon> = {};
-                const datasetData: Record<string, Dataset> = {};
-
-                if (data.facets && data.facets.length > 0) {
-                    await this.processTaxonFacets(data.facets, taxonsData);
-                    this.processDatasetFacets(data.facets, datasetData);
-                }
-
-                return {
-                    taxons: Object.values(taxonsData),
-                    datasets: Object.values(datasetData),
-                };
-            });
-    }
-
-    /**
-     * Builds search parameters for the GBIF API.
-     * Merges default parameters with user-provided ones.
-     * Handles date transformation and taxonomic class mapping.
-     *
-     * @param params - Custom search parameters
-     * @returns Formatted parameters for the GBIF API
-     */
-    private buildSearchParams(params: any): OccurrenceParams {
-        let searchParams = {
+        const defaultParams = {
+            facet: ['speciesKey', 'datasetKey'],
+            facetLimit: this.LIMIT,
+            limit: 0,
             occurrenceStatus: 'PRESENT',
             basisOfRecord: [
                 'OBSERVATION',
@@ -136,249 +278,124 @@ export class GbifFacetConnector extends Connector {
             ],
             hasGeospatialIssue: false,
             hasCoordinate: true,
-            facet: ['taxonKey', 'datasetKey'],
-            facetLimit: this.LIMIT,
-            limit: 0,
             ...params,
         };
 
-        // Gestion de la plage de dates
-        if (searchParams.dateMin && searchParams.dateMax) {
-            searchParams.eventDate = `${searchParams.dateMin},${searchParams.dateMax}`;
-            delete searchParams.dateMin;
-            delete searchParams.dateMax;
+        if (defaultParams.dateMin && defaultParams.dateMax) {
+            defaultParams.eventDate = `${defaultParams.dateMin},${defaultParams.dateMax}`;
+            delete defaultParams.dateMin;
+            delete defaultParams.dateMax;
         }
 
-        // Gestion de la classe taxonomique
         if (params?.class) {
-            searchParams.classKey = this.taxonClass2SourceID[params.class];
-            delete searchParams.class;
+            defaultParams.classKey = this.taxonClass2SourceID[params?.class];
+            delete defaultParams.class;
         }
 
-        return searchParams;
-    }
+        return callOccurrenceApi(defaultParams).then(async (gbifData) => {
+            if (!gbifData.facets || gbifData.facets.length === 0)
+                return { taxons: [], datasets: [] };
 
-    /**
-     * Builds the complete URL for the GBIF search query.
-     * Properly encodes simple parameters and arrays.
-     *
-     * @param params - Search parameters to encode in the URL
-     * @returns Complete URL with all parameters
-     */
-    private buildSearchUrl(params: OccurrenceParams): URL {
-        const url = new URL(`${this.GBIF_ENDPOINT}/occurrence/search`);
-
-        Object.entries(params).forEach(([key, value]) => {
-            if (Array.isArray(value)) {
-                value.forEach((item) => url.searchParams.append(key, item));
-            } else {
-                url.searchParams.append(key, value);
-            }
-        });
-
-        return url;
-    }
-
-    /**
-     * Processes taxon facets returned by the GBIF API.
-     * Retrieves detailed information for each taxon in parallel.
-     * Filters taxa based on their taxonomic rank.
-     *
-     * @param facets - List of facets returned by the API
-     * @param taxonsData - Object to store validated taxon data
-     */
-    private async processTaxonFacets(
-        facets: any[],
-        taxonsData: Record<string, Taxon>
-    ): Promise<void> {
-        const taxonFacet = facets.find((f: any) => f.field === 'TAXON_KEY');
-
-        if (!taxonFacet?.counts) {
-            return;
-        }
-
-        const BATCH_SIZE = 50; // Process 10 taxa at a time
-
-        for (let i = 0; i < taxonFacet.counts.length; i += BATCH_SIZE) {
-            const batch = taxonFacet.counts.slice(i, i + BATCH_SIZE);
-            const batchPromises = batch.map((facetItem: any) =>
-                this.processSingleTaxon(facetItem, taxonsData)
+            const taxonFacet = gbifData.facets.find(
+                (f: any) => f.field === 'SPECIES_KEY'
             );
-            await Promise.all(batchPromises);
-        }
-    }
-
-    /**
-     * Processes an individual taxon from the facet.
-     * Retrieves its information from the GBIF API and validates its taxonomic rank.
-     * If the rank is valid, adds the taxon to the collection.
-     *
-     * @param facetItem - Facet item containing the taxonKey and count
-     * @param taxonsData - Collection to add the taxon to if valid
-     */
-    private async processSingleTaxon(
-        facetItem: any,
-        taxonsData: Record<string, Taxon>
-    ): Promise<void> {
-        const taxonKey = facetItem.name;
-        const nbObservations = facetItem.count;
-
-        try {
-            const taxonInfo = await this.fetchTaxonInfo(taxonKey);
-
-            if (!this.isValidTaxonRank(taxonInfo.rank)) {
-                return;
-            }
-
-            taxonsData[taxonKey] = this.createTaxonObject(
-                taxonKey,
-                taxonInfo,
-                nbObservations
+            const datasetFacet = gbifData.facets.find(
+                (f: any) => f.field === 'DATASET_KEY'
             );
-        } catch (error) {
-            console.error(
-                `Erreur lors de la récupération du taxon ${taxonKey}:`,
-                error
+
+            const datasets: Dataset[] =
+                datasetFacet?.counts.map((facet: any) => ({
+                    uuid: facet.name,
+                    name: facet.name,
+                    nbObservations: facet.count,
+                })) || [];
+
+            if (!taxonFacet || !taxonFacet.counts)
+                return { taxons: [], datasets };
+
+            const speciesIds = taxonFacet.counts.map((f: any) => f.name);
+            const enrichmentMap = await this.enrichTaxonomy(speciesIds);
+
+            const taxons: TaxonWithAncestors[] = taxonFacet.counts.map(
+                (facet: any) => {
+                    const gbifId = facet.name;
+                    const enrichment = enrichmentMap.get(gbifId);
+
+                    const taxon: Taxon = {
+                        taxonId: gbifId,
+                        acceptedScientificName:
+                            enrichment?.scientificName || '',
+                        vernacularName: enrichment?.commonName || '',
+                        taxonRank: 'SPECIES',
+                        nbObservations: facet.count,
+                        mediaUrl: enrichment?.photo || NO_IMAGE_URL,
+                        description: '',
+                        lastSeenDate: new Date(),
+                        kingdom: enrichment?.kingdom || '',
+                        class: enrichment?.iconicTaxonName || '',
+                    };
+
+                    return taxon;
+                }
             );
-        }
-    }
 
-    /**
-     * Creates a standardized Taxon object from retrieved information.
-     *
-     * @param taxonKey - Unique identifier of the taxon in GBIF
-     * @param taxonInfo - Taxon information (scientific name, vernacular name, rank)
-     * @param nbObservations - Number of observations for this taxon
-     * @returns Formatted Taxon object
-     */
-    private createTaxonObject(
-        taxonKey: string,
-        taxonInfo: {
-            scientificName: string;
-            vernacularName: string;
-            rank: string;
-        },
-        nbObservations: number
-    ): Taxon {
-        return {
-            acceptedScientificName: taxonInfo.scientificName,
-            vernacularName: taxonInfo.vernacularName || '',
-            taxonId: taxonKey,
-            mediaUrl: NO_IMAGE_URL,
-            taxonRank: taxonInfo.rank,
-            kingdom: '',
-            class: '',
-            nbObservations: nbObservations,
-            description: '',
-            // lastSeenDate: new Date(),
-        };
-    }
-
-    /**
-     * Processes dataset facets returned by the GBIF API.
-     * Extracts information from each dataset (UUID, number of observations).
-     *
-     * @param facets - List of facets returned by the API
-     * @param datasetData - Object to store dataset data
-     */
-    private processDatasetFacets(
-        facets: any[],
-        datasetData: Record<string, Dataset>
-    ): void {
-        const datasetFacet = facets.find((f: any) => f.field === 'DATASET_KEY');
-
-        if (!datasetFacet?.counts) {
-            return;
-        }
-
-        datasetFacet.counts.forEach((facetItem: any) => {
-            datasetData[facetItem.name] = {
-                uuid: facetItem.name,
-                name: facetItem.name,
-                nbObservations: facetItem.count,
-            };
+            return { taxons, datasets };
         });
     }
 
-    /**
-     * Checks if a taxonomic rank is specific enough.
-     * Filters out ranks that are too high like family, order, class, etc.
-     *
-     * @param rank - Taxonomic rank to validate (e.g., 'SPECIES', 'GENUS', 'FAMILY')
-     * @returns true if the rank is accepted, false otherwise
-     */
-    private isValidTaxonRank(rank: string): boolean {
-        const acceptedRanks = ['SPECIES', 'SUBSPECIES'];
-        return acceptedRanks.includes(rank.toUpperCase());
-    }
-
-    fetchTaxonInfo(idTaxon: string): Promise<{
-        scientificName: string;
-        vernacularName: string;
-        rank: string;
-        taxonKey: number;
-    }> {
-        const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}`;
-        return fetch(url)
-            .then((response) => response.json())
-            .then((json) => ({
+    fetchTaxonInfo(idTaxon: string) {
+        return fetchJson<any>(`${this.GBIF_ENDPOINT}/species/${idTaxon}`).then(
+            (json) => ({
                 scientificName: json.scientificName,
                 vernacularName: json.vernacularName,
                 rank: json.rank,
                 taxonKey: json.key,
-            }));
+            })
+        );
     }
 
-    fetchTaxonStatus(idTaxon: string): Promise<{
-        iucnRedListCategory: string;
-        code: string;
-    }> {
-        const url = `${this.GBIF_ENDPOINT}/species/${idTaxon}/iucnRedListCategory`;
-        return fetch(url)
-            .then((response) => response.json())
-            .then((json) => ({
-                iucnRedListCategory: json.category,
-                code: json.code,
-            }));
+    fetchTaxonStatus(idTaxon: string) {
+        return fetchJson<{ category: string; code: string }>(
+            `${this.GBIF_ENDPOINT}/species/${idTaxon}/iucnRedListCategory`
+        ).then((json) => ({
+            iucnRedListCategory: json.category,
+            code: json.code,
+        }));
     }
 
-    searchTaxon(
-        searchString: string = '',
-        params: OccurrenceParams = {}
-    ): Promise<Array<{ scientificName: string; taxonKey: number }>> {
-        const url = `${this.GBIF_ENDPOINT}/species/search?q=${searchString}&limit=20`;
-        return fetch(url)
-            .then((response) => response.json())
-            .then((json) =>
-                json.results.map((element: any) => ({
-                    scientificName: element.scientificName,
-                    taxonKey: element.key,
-                }))
-            );
+    searchTaxon(searchString: string = '', params: OccurrenceParams = {}) {
+        return fetchJson<any>(
+            `${this.GBIF_ENDPOINT}/species/search?q=${searchString}&limit=20`
+        ).then((json) =>
+            json.results.map((e: any) => ({
+                scientificName: e.scientificName,
+                taxonKey: e.key,
+            }))
+        );
     }
 
-    getTaxonDetailPage(taxonId: string): string {
+    getTaxonDetailPage(taxonId: string) {
         return `https://www.gbif.org/species/${taxonId}`;
     }
 
-    sourceDetailMessage(): string {
+    sourceDetailMessage() {
         return useI18n().t('source.gbifWarning', {
-            nbTaxons: GBIF_DEFAULT_TAXON_LIMIT,
+            nbObs: this.LIMIT * this.NB_PAGES,
         });
     }
-    getSourceUrl(): string | null {
+
+    getSourceUrl() {
         return 'https://www.gbif.org';
     }
-
-    getDatasetUrl(datasetID: any): string | null {
+    getDatasetUrl(datasetID: any) {
         return `${this.getSourceUrl()}/dataset/${datasetID}`;
     }
 
-    searchOnAPI(searchString: string): Promise<any> {
-        return fetch(
+    searchOnAPI(searchString: string) {
+        return fetchJson<any>(
             `${this.GBIF_ENDPOINT}/species/search?q=${searchString}&status=ACCEPTED&qField=VERNACULAR&limit=100`
-        )
-            .then((response) => response.json())
-            .then((json) => json.results);
+        ).then((json) => json.results);
     }
 }
+
+export default GbifFacetConnector;

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -359,7 +359,7 @@ export class GbifFacetConnector extends Connector {
 
     sourceDetailMessage(): string {
         return useI18n().t('source.gbifWarning', {
-            nbObs: GBIF_DEFAULT_TAXON_LIMIT,
+            nbTaxons: GBIF_DEFAULT_TAXON_LIMIT,
         });
     }
     getSourceUrl(): string | null {

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -197,11 +197,15 @@ export class GbifFacetConnector extends Connector {
             return;
         }
 
-        const taxonPromises = taxonFacet.counts.map((facetItem: any) =>
-            this.processSingleTaxon(facetItem, taxonsData)
-        );
+        const BATCH_SIZE = 50; // Process 10 taxa at a time
 
-        await Promise.all(taxonPromises); // TODO : watch out for performance
+        for (let i = 0; i < taxonFacet.counts.length; i += BATCH_SIZE) {
+            const batch = taxonFacet.counts.slice(i, i + BATCH_SIZE);
+            const batchPromises = batch.map((facetItem: any) =>
+                this.processSingleTaxon(facetItem, taxonsData)
+            );
+            await Promise.all(batchPromises);
+        }
     }
 
     /**

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -384,10 +384,7 @@ export class GbifFacetConnector extends Connector {
     fetchTaxonStatus(idTaxon: string) {
         return fetchJson<{ category: string; code: string }>(
             `${this.GBIF_ENDPOINT}/species/${idTaxon}/iucnRedListCategory`
-        ).then((json) => ({
-            iucnRedListCategory: json.category,
-            code: json.code,
-        }));
+        ).then((json) => json.code);
     }
 
     searchTaxon(searchString: string = '', params: OccurrenceParams = {}) {

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -1,5 +1,5 @@
 import { Connector, ConnectorOptions } from './connector';
-import { Dataset, SearchResult, Taxon } from '../models';
+import { Dataset, SearchResult, Taxon, Media, MediaType } from '../models';
 import ParameterStore from '../parameterStore';
 import { NO_IMAGE_URL } from '@/assets/constant';
 import { TAXON_REFERENTIAL } from '../taxonReferential';
@@ -40,7 +40,7 @@ interface WikidataBinding {
 interface EnrichedTaxonData {
     scientificName?: string;
     commonName?: string;
-    photo?: string;
+    medias?: Media[];
     iNatId?: string;
     ancestors?: any[];
     kingdom?: string;
@@ -224,15 +224,25 @@ export class GbifFacetConnector extends Connector {
             const wikidataData = await wikidataResponse.json();
 
             // Process Wikidata results - now includes parent taxon ranks
+            // Store basic media info (filename) without fetching credits
+            // Credits will be fetched on-demand when detailed view is rendered
             wikidataData.results.bindings.forEach((b: WikidataBinding) => {
                 const gbifId = b.gbifID.value;
+                let medias: Media[] = [];
 
-                // Transform Wikidata image URL to use Wikimedia Commons thumbnail
-                let photoUrl = b.image?.value;
-                if (photoUrl) {
-                    const fileName = photoUrl.split('/').pop();
-                    if (fileName) {
-                        photoUrl = `https://commons.wikimedia.org/w/thumb.php?width=400&f=${fileName}`;
+                // Store basic media with thumbnail URL and filename for later credit fetching
+                if (b.image?.value) {
+                    const encodedFileName = b.image.value.split('/').pop();
+                    if (encodedFileName) {
+                        // Decode the filename from the Wikidata URL
+                        const fileName = decodeURIComponent(encodedFileName);
+                        medias = [
+                            {
+                                url: `https://commons.wikimedia.org/w/thumb.php?width=400&f=${encodeURIComponent(fileName)}`,
+                                typeMedia: MediaType.image,
+                                source: fileName, // Store decoded filename for later credit fetching
+                            },
+                        ];
                     }
                 }
 
@@ -241,7 +251,7 @@ export class GbifFacetConnector extends Connector {
                     commonName: b.commonName?.value?.replace(/^./, (char) =>
                         char.toUpperCase()
                     ),
-                    photo: photoUrl,
+                    medias,
                     iNatId: b.iNatID?.value,
                     // Parent taxon ranks from Wikidata - eliminates need for iNaturalist
                     kingdom: b.kingdomLabel?.value,
@@ -331,6 +341,12 @@ export class GbifFacetConnector extends Connector {
                     const gbifId = facet.name;
                     const enrichment = enrichmentMap.get(gbifId);
 
+                    // For backward compatibility, set mediaUrl to first image or NO_IMAGE_URL
+                    const firstImageUrl =
+                        enrichment?.medias?.find(
+                            (m) => m.typeMedia === MediaType.image
+                        )?.url || NO_IMAGE_URL;
+
                     const taxon: Taxon = {
                         taxonId: gbifId,
                         acceptedScientificName:
@@ -338,7 +354,8 @@ export class GbifFacetConnector extends Connector {
                         vernacularName: enrichment?.commonName || '',
                         taxonRank: 'SPECIES',
                         nbObservations: facet.count,
-                        mediaUrl: enrichment?.photo || NO_IMAGE_URL,
+                        mediaUrl: firstImageUrl, // Backward compatibility
+                        medias: enrichment?.medias || [],
                         description: '',
                         lastSeenDate: new Date(),
                         kingdom: enrichment?.kingdom || '',

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -275,6 +275,8 @@ export class GbifFacetConnector extends Connector {
     /* ---------- fetchOccurrence ---------- */
     fetchOccurrence(params: any = {}): Promise<SearchResult> {
         super.fetchOccurrence(params);
+        const { t } = useI18n();
+
         if (params.geometry)
             params.geometry = stringify(removeHoles(parse(params.geometry)));
 
@@ -305,7 +307,13 @@ export class GbifFacetConnector extends Connector {
             delete defaultParams.class;
         }
 
+        // Step 1 (25%): API GBIF call
+        this.reportProgress(25, t('gbif.progress.fetching'));
+
         return callOccurrenceApi(defaultParams).then(async (gbifData) => {
+            // Step 2 (50%): Extract facets
+            this.reportProgress(50, t('gbif.progress.processing'));
+
             if (!gbifData.facets || gbifData.facets.length === 0)
                 return { taxons: [], datasets: [] };
 
@@ -326,6 +334,9 @@ export class GbifFacetConnector extends Connector {
             if (!taxonFacet || !taxonFacet.counts)
                 return { taxons: [], datasets };
 
+            // Step 3 (75%): Wikidata enrichment
+            this.reportProgress(75, t('gbif.progress.enriching'));
+
             // Parallel prefetch: Start Wikidata enrichment immediately, don't await yet
             const speciesIds = taxonFacet.counts.map((f: any) => f.name);
             const enrichmentPromise = this.enrichTaxonomy(speciesIds);
@@ -335,6 +346,9 @@ export class GbifFacetConnector extends Connector {
 
             // Now await the enrichment data
             const enrichmentMap = await enrichmentPromise;
+
+            // Step 4 (100%): Build taxons
+            this.reportProgress(100, t('gbif.progress.finalizing'));
 
             const taxons: TaxonWithAncestors[] = taxonFacet.counts.map(
                 (facet: any) => {

--- a/src/lib/connectors/gbiffacet.ts
+++ b/src/lib/connectors/gbiffacet.ts
@@ -14,8 +14,6 @@ import { fetchJson } from '../utils';
 const GBIF_ENDPOINT_DEFAULT = 'https://api.gbif.org/v1';
 const GBIF_DEFAULT_TAXON_LIMIT = 1000;
 const WIKIDATA_SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
-const INAT_API_ENDPOINT = 'https://api.inaturalist.org/v1/taxa';
-const INAT_BATCH_SIZE = 30;
 
 type OccurrenceParams = Record<string, any>;
 
@@ -29,8 +27,14 @@ interface WikidataBinding {
     gbifID: { value: string };
     iNatID?: { value: string };
     scientificName?: { value: string };
-    commonName?: { value: string }; // nouveau
+    commonName?: { value: string };
     image?: { value: string };
+    kingdomLabel?: { value: string };
+    phylumLabel?: { value: string };
+    classLabel?: { value: string };
+    orderLabel?: { value: string };
+    familyLabel?: { value: string };
+    genusLabel?: { value: string };
 }
 
 interface EnrichedTaxonData {
@@ -146,6 +150,7 @@ export class GbifFacetConnector extends Connector {
         const values = gbifIds.map((id) => `"${id}"`).join(' ');
         return `
         SELECT ?gbifID ?iNatID ?scientificName ?commonName ?image
+               ?kingdomLabel ?phylumLabel ?classLabel ?orderLabel ?familyLabel ?genusLabel
         WHERE {
             VALUES ?gbifID { ${values} }
             ?taxon wdt:P846 ?gbifID .
@@ -156,6 +161,38 @@ export class GbifFacetConnector extends Connector {
                        FILTER(LANG(?commonName) = "${lang}")
             }
             OPTIONAL { ?taxon wdt:P18 ?image . }
+            
+            # Walk the taxonomy tree to get parent taxon ranks - use scientific names directly
+            OPTIONAL {
+                ?taxon wdt:P171* ?kingdom .
+                ?kingdom wdt:P105 wd:Q36732 .
+                ?kingdom wdt:P225 ?kingdomLabel .
+            }
+            OPTIONAL {
+                ?taxon wdt:P171* ?phylum .
+                ?phylum wdt:P105 wd:Q38348 .
+                ?phylum wdt:P225 ?phylumLabel .
+            }
+            OPTIONAL {
+                ?taxon wdt:P171* ?class .
+                ?class wdt:P105 wd:Q37517 .
+                ?class wdt:P225 ?classLabel .
+            }
+            OPTIONAL {
+                ?taxon wdt:P171* ?order .
+                ?order wdt:P105 wd:Q36602 .
+                ?order wdt:P225 ?orderLabel .
+            }
+            OPTIONAL {
+                ?taxon wdt:P171* ?family .
+                ?family wdt:P105 wd:Q35409 .
+                ?family wdt:P225 ?familyLabel .
+            }
+            OPTIONAL {
+                ?taxon wdt:P171* ?genus .
+                ?genus wdt:P105 wd:Q34740 .
+                ?genus wdt:P225 ?genusLabel .
+            }
         }
     `;
     }
@@ -167,11 +204,10 @@ export class GbifFacetConnector extends Connector {
             (id) => !this.enrichTaxonomyCache.has(id)
         );
         if (!uncachedIds.length) return this.enrichTaxonomyCache;
-
         const currentLang = ParameterStore.getInstance().lang.value;
 
         try {
-            // Fetch all Wikidata IDs in a single POST
+            // Fetch all Wikidata data in a single POST (no URL length limit)
             const sparql = this.buildWikidataSparql(uncachedIds, currentLang);
             const wikidataResponse = await fetch(WIKIDATA_SPARQL_ENDPOINT, {
                 method: 'POST',
@@ -187,70 +223,37 @@ export class GbifFacetConnector extends Connector {
                 );
             const wikidataData = await wikidataResponse.json();
 
-            // Process Wikidata results
-            const gbifToINat: Record<string, string> = {};
+            // Process Wikidata results - now includes parent taxon ranks
             wikidataData.results.bindings.forEach((b: WikidataBinding) => {
                 const gbifId = b.gbifID.value;
-                const existing = this.enrichTaxonomyCache.get(gbifId) || {};
-                this.enrichTaxonomyCache.set(gbifId, {
-                    ...existing,
+
+                // Transform Wikidata image URL to use Wikimedia Commons thumbnail
+                let photoUrl = b.image?.value;
+                if (photoUrl) {
+                    const fileName = photoUrl.split('/').pop();
+                    if (fileName) {
+                        photoUrl = `https://commons.wikimedia.org/w/thumb.php?width=400&f=${fileName}`;
+                    }
+                }
+
+                const enrichedData: EnrichedTaxonData = {
                     scientificName: b.scientificName?.value,
-                    commonName: b.commonName?.value.replace(/^./, (char) =>
+                    commonName: b.commonName?.value?.replace(/^./, (char) =>
                         char.toUpperCase()
                     ),
-                    photo: b.image?.value,
-                });
-                if (b.iNatID) gbifToINat[gbifId] = b.iNatID.value;
-            });
+                    photo: photoUrl,
+                    iNatId: b.iNatID?.value,
+                    // Parent taxon ranks from Wikidata - eliminates need for iNaturalist
+                    kingdom: b.kingdomLabel?.value,
+                    phylum: b.phylumLabel?.value,
+                    order: b.orderLabel?.value,
+                    family: b.familyLabel?.value,
+                    genus: b.genusLabel?.value,
+                    // Use class as iconicTaxonName for backward compatibility
+                    iconicTaxonName: b.classLabel?.value,
+                };
 
-            // iNaturalist
-            const iNatIds = Object.values(gbifToINat);
-            const iNatPromises: Promise<any>[] = [];
-            for (let i = 0; i < iNatIds.length; i += INAT_BATCH_SIZE) {
-                const batch = iNatIds.slice(i, i + INAT_BATCH_SIZE);
-                if (!batch.length) continue;
-                iNatPromises.push(
-                    fetchJson(`${INAT_API_ENDPOINT}/${batch.join(',')}`)
-                );
-            }
-
-            const iNatResults = await Promise.all(iNatPromises);
-
-            // Merge iNaturalist data into cache
-            iNatResults.forEach((iNatData) => {
-                Object.entries(gbifToINat).forEach(([gbifId, iNatId]) => {
-                    const taxon = iNatData.results.find(
-                        (t: any) => t.id == iNatId
-                    );
-                    if (!taxon) return;
-                    const existing = this.enrichTaxonomyCache.get(gbifId) || {};
-                    this.enrichTaxonomyCache.set(gbifId, {
-                        ...existing,
-                        iNatId,
-                        scientificName: taxon.name,
-                        commonName:
-                            existing.commonName || taxon.preferred_common_name,
-                        ancestors: taxon.ancestors || [],
-                        kingdom: taxon.ancestors?.find(
-                            (a: any) => a.rank === 'kingdom'
-                        )?.name,
-                        phylum: taxon.ancestors?.find(
-                            (a: any) => a.rank === 'phylum'
-                        )?.name,
-                        order: taxon.ancestors?.find(
-                            (a: any) => a.rank === 'order'
-                        )?.name,
-                        family: taxon.ancestors?.find(
-                            (a: any) => a.rank === 'family'
-                        )?.name,
-                        genus: taxon.ancestors?.find(
-                            (a: any) => a.rank === 'genus'
-                        )?.name,
-                        iconicTaxonName: taxon.iconic_taxon_name, // equivalent of the functional group in INPN
-                        photo:
-                            taxon.default_photo?.medium_url || existing.photo,
-                    });
-                });
+                this.enrichTaxonomyCache.set(gbifId, enrichedData);
             });
         } catch (e) {
             console.error(`[${this.name}] enrichTaxonomy failed`, e);
@@ -313,8 +316,15 @@ export class GbifFacetConnector extends Connector {
             if (!taxonFacet || !taxonFacet.counts)
                 return { taxons: [], datasets };
 
+            // Parallel prefetch: Start Wikidata enrichment immediately, don't await yet
             const speciesIds = taxonFacet.counts.map((f: any) => f.name);
-            const enrichmentMap = await this.enrichTaxonomy(speciesIds);
+            const enrichmentPromise = this.enrichTaxonomy(speciesIds);
+
+            // Do any other synchronous work here while Wikidata fetches in parallel
+            // (In this case, datasets are already processed above)
+
+            // Now await the enrichment data
+            const enrichmentMap = await enrichmentPromise;
 
             const taxons: TaxonWithAncestors[] = taxonFacet.counts.map(
                 (facet: any) => {

--- a/src/lib/connectors/geonature.ts
+++ b/src/lib/connectors/geonature.ts
@@ -138,10 +138,9 @@ export class GeoNatureConnector extends Connector {
     }
 
     fetchTaxonStatus(idTaxon: string): Promise<any> {
-        const url = `https://taxref.mnhn.fr/api/taxa/${idTaxon}/status/columns`;
-        return fetch(url)
-            .then((response) => response.json())
-            .then((json) => json._embedded?.status);
+        // GeoNature uses Taxref status system, not IUCN Red List
+        // Return null to indicate IUCN status is not available
+        return Promise.resolve(null);
     }
 
     getTaxonDetailPage(taxonId: string): string {

--- a/src/lib/connectors/utils.ts
+++ b/src/lib/connectors/utils.ts
@@ -1,6 +1,7 @@
 import { CONNECTORS } from './connectors';
 import { GbifConnector } from './gbif';
 import { GeoNatureConnector } from './geonature';
+import { GbifFacetConnector } from './gbiffacet';
 import { Connector } from './connector';
 import { simplify, truncate } from '@turf/turf';
 import { Feature, Polygon, MultiPolygon } from 'geojson';
@@ -17,8 +18,10 @@ export function getConnector(
             return new GbifConnector(params);
         case CONNECTORS.GeoNature:
             return new GeoNatureConnector(params);
+        case CONNECTORS.GBIF_FACET:
+            return new GbifFacetConnector(params);
         default:
-            return new GbifConnector(params);
+            return new GbifFacetConnector(params);
     }
 }
 

--- a/src/lib/media/MediaSource.ts
+++ b/src/lib/media/MediaSource.ts
@@ -37,4 +37,15 @@ export abstract class MediaSource {
         }
         return new Promise((_) => null);
     }
+
+    /**
+     * Returns the credits for a given media item. Used when the media
+     * are fetched without credits information,
+     * to enrich them with the necessary details to be displayed in the UI.
+     * @param {Media} media - The media item.
+     * @returns {Promise<Media>} The media item with credits information.
+     */
+    getCredits(media: Media): Promise<Media> {
+        throw new Error('Not implemented');
+    }
 }

--- a/src/lib/media/Wikidata.ts
+++ b/src/lib/media/Wikidata.ts
@@ -44,59 +44,6 @@ function fetchWikidataEntityByProperty(
 }
 
 /**
- * Fetch metadata for a Commons file (image or audio)
- */
-function fetchCommonsMedia(
-    fileName: string,
-    typeMedia: MediaType
-): Promise<Media[]> {
-    const commonsUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=File:${encodeURIComponent(
-        fileName
-    )}&prop=imageinfo&iiprop=url|extmetadata&format=json&origin=*`;
-
-    return fetch(commonsUrl)
-        .then((res) => res.json())
-        .then((commonsData) => {
-            const pages = commonsData.query.pages;
-            const page = Object.values(pages)[0] as any;
-
-            if (!page?.imageinfo?.length) {
-                return [];
-            }
-
-            const info = page.imageinfo[0];
-            const meta = info.extmetadata || {};
-            const credit = {
-                artist: meta.Artist?.value || null,
-                license: meta.LicenseShortName?.value || null,
-                creditLine: meta.Credit?.value || null,
-                licenseUrl: meta.LicenseUrl?.value || null,
-            };
-
-            return [
-                {
-                    url:
-                        typeMedia === MediaType.image
-                            ? `https://commons.wikimedia.org/w/thumb.php?width=400&f=${fileName}`
-                            : info.url,
-                    source: `${
-                        credit.artist
-                            ? credit.artist.replace(/<[^>]*>?/gm, '')
-                            : ''
-                    } - ${credit.license}`,
-                    typeMedia,
-                    licenseUrl: credit.licenseUrl,
-                    license: credit.license,
-                    author: credit.artist
-                        ? credit.artist.replace(/<[^>]*>?/gm, '')
-                        : credit.artist,
-                    urlSource: `https://commons.wikimedia.org/wiki/File:${fileName}`,
-                },
-            ] as Media[];
-        });
-}
-
-/**
  * Generic fetcher for Wikidata media (image/audio)
  */
 function fetchMediaFromWikidata(
@@ -122,7 +69,52 @@ function fetchMediaFromWikidata(
             }
 
             const fileName = mediaClaims[0].mainsnak.datavalue.value;
-            return fetchCommonsMedia(fileName, typeMedia);
+
+            // Inline fetch Commons metadata
+            const commonsUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=File:${encodeURIComponent(
+                fileName
+            )}&prop=imageinfo&iiprop=url|extmetadata&format=json&origin=*`;
+
+            return fetch(commonsUrl)
+                .then((res) => res.json())
+                .then((commonsData) => {
+                    const pages = commonsData.query.pages;
+                    const page = Object.values(pages)[0] as any;
+
+                    if (!page?.imageinfo?.length) {
+                        return [];
+                    }
+
+                    const info = page.imageinfo[0];
+                    const meta = info.extmetadata || {};
+                    const credit = {
+                        artist: meta.Artist?.value || null,
+                        license: meta.LicenseShortName?.value || null,
+                        creditLine: meta.Credit?.value || null,
+                        licenseUrl: meta.LicenseUrl?.value || null,
+                    };
+
+                    return [
+                        {
+                            url:
+                                typeMedia === MediaType.image
+                                    ? `https://commons.wikimedia.org/w/thumb.php?width=700&f=${fileName}`
+                                    : info.url,
+                            source: `${
+                                credit.artist
+                                    ? credit.artist.replace(/<[^>]*>?/gm, '')
+                                    : ''
+                            } - ${credit.license}`,
+                            typeMedia,
+                            licenseUrl: credit.licenseUrl,
+                            license: credit.license,
+                            author: credit.artist
+                                ? credit.artist.replace(/<[^>]*>?/gm, '')
+                                : credit.artist,
+                            urlSource: `https://commons.wikimedia.org/wiki/File:${fileName}`,
+                        },
+                    ] as Media[];
+                });
         });
 }
 
@@ -206,6 +198,66 @@ class WikiDataImageSource extends MediaSource {
 
     isCompatible(connector: any): boolean {
         return [GBIF, TAXREF].includes(connector.referential);
+    }
+
+    /**
+     * Fetch full credits for a media item that only has basic info.
+     * Expects the filename to be stored in media.source field.
+     * @param {Media} media - The media item with basic info (must have source field with filename)
+     * @returns {Promise<Media>} The media item enriched with full credits
+     */
+    async getCredits(media: Media): Promise<Media> {
+        if (!media.source) {
+            throw new Error('Media source field must contain the filename');
+        }
+
+        const fileName = media.source;
+        const typeMedia = media.typeMedia;
+
+        // Fetch metadata from Commons API
+        const commonsUrl = `https://commons.wikimedia.org/w/api.php?action=query&titles=File:${encodeURIComponent(
+            fileName
+        )}&prop=imageinfo&iiprop=url|extmetadata&format=json&origin=*`;
+
+        try {
+            const res = await fetch(commonsUrl);
+            const commonsData = await res.json();
+            const pages = commonsData.query.pages;
+            const page = Object.values(pages)[0] as any;
+
+            if (!page?.imageinfo?.length) {
+                return media; // Return original if no info found
+            }
+
+            const info = page.imageinfo[0];
+            const meta = info.extmetadata || {};
+            const credit = {
+                artist: meta.Artist?.value || null,
+                license: meta.LicenseShortName?.value || null,
+                creditLine: meta.Credit?.value || null,
+                licenseUrl: meta.LicenseUrl?.value || null,
+            };
+
+            return {
+                url:
+                    typeMedia === MediaType.image
+                        ? `https://commons.wikimedia.org/w/thumb.php?width=700&f=${fileName}`
+                        : info.url,
+                source: `${
+                    credit.artist ? credit.artist.replace(/<[^>]*>?/gm, '') : ''
+                } - ${credit.license}`,
+                typeMedia,
+                licenseUrl: credit.licenseUrl,
+                license: credit.license,
+                author: credit.artist
+                    ? credit.artist.replace(/<[^>]*>?/gm, '')
+                    : credit.artist,
+                urlSource: `https://commons.wikimedia.org/wiki/File:${fileName}`,
+            } as Media;
+        } catch (error) {
+            console.error('Failed to fetch Commons media credits:', error);
+            return media; // Return original on error
+        }
     }
 }
 

--- a/src/lib/media/Wikidata.ts
+++ b/src/lib/media/Wikidata.ts
@@ -77,7 +77,7 @@ function fetchCommonsMedia(
                 {
                     url:
                         typeMedia === MediaType.image
-                            ? `https://commons.wikimedia.org/w/thumb.php?width=700&f=${fileName}`
+                            ? `https://commons.wikimedia.org/w/thumb.php?width=400&f=${fileName}`
                             : info.url,
                     source: `${
                         credit.artist

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -10,6 +10,10 @@ export interface Taxon {
     lastSeenDate?: Date | null;
     kingdom?: string;
     class?: string;
+    phylum?: string;
+    order?: string;
+    family?: string;
+    genus?: string;
 }
 export enum MediaType {
     sound = 'sound',

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,7 +3,8 @@ export interface Taxon {
     acceptedScientificName: string;
     vernacularName?: string;
     nbObservations?: number;
-    mediaUrl?: string;
+    mediaUrl?: string; // Deprecated: use medias instead
+    medias?: Media[];
     taxonRank?: string;
     description?: string;
     taxonSheetUrl?: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -96,6 +96,19 @@ function isRunningOnMobile() {
     return check;
 }
 
+/**
+ * Fetches JSON data from a given URL and returns it as a promise.
+ * If the HTTP response is not OK, it throws an error with the HTTP status code.
+ * @template T The type of the JSON data to be fetched.
+ * @param {string} url The URL to fetch the JSON data from.
+ * @returns {Promise<T>} A promise resolving to the fetched JSON data.
+ */
+async function fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response.json();
+}
+
 export {
     toWKT,
     restoreMapState,
@@ -103,4 +116,5 @@ export {
     getBaseUrl,
     validURL,
     isRunningOnMobile,
+    fetchJson,
 };

--- a/tests/configurator.spec.ts
+++ b/tests/configurator.spec.ts
@@ -21,9 +21,7 @@ async function checkForParameterChange(page, key, value) {
 
 test.describe('Form parameters testing', () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto(
-            '/#/config?widgetType=mapList&lang=fr&GBIF_ENDPOINT=https://api.gbif-uat.org/v1/'
-        );
+        await page.goto('/#/config?widgetType=mapList&lang=fr');
     });
 
     test('enable/disable filter', async ({ page }) => {

--- a/tests/list.spec.ts
+++ b/tests/list.spec.ts
@@ -5,7 +5,7 @@ import { TaxonList } from './page/taxonlistcontroller';
 test.describe('Simple list', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto(
-            'http://localhost:5173/#/?widgetType=list&x=6.076641082763673&y=44.55164823782743&GBIF_ENDPOINT=https://api.gbif-uat.org/v1/&showFilters=true&lang=en&switchModeAvailable=true'
+            'http://localhost:5173/#/?widgetType=list&x=6.076641082763673&y=44.55164823782743&showFilters=true&lang=en&switchModeAvailable=true'
         );
     });
     test('sort', async ({ page }) => {

--- a/tests/maplist.spec.ts
+++ b/tests/maplist.spec.ts
@@ -4,9 +4,7 @@ import { TaxonList } from './page/taxonlistcontroller';
 
 test.describe('Map list', () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto(
-            'http://localhost:5173/#/?GBIF_ENDPOINT=https://api.gbif-uat.org/v1/'
-        );
+        await page.goto('http://localhost:5173/#/');
     });
     test('should load map list', async ({ page }) => {
         await page.locator('.mapC').isVisible();


### PR DESCRIPTION
## Part of PR #32

This PR proposes using the *facet* feature in the GBIF API, which offers several key advantages:
- **Performance**: It is faster and lighter than the standard `occurrences/search` query.
- **Accuracy**: It provides the true count of occurrences in a specified area.

However, the GBIF API only returns GBIF taxon identifiers. To avoid making N separate queries (where N = number of taxa) to fetch missing data for each taxon, we query the Wikidata API. This allows us to retrieve, in a single request, information such as:
- Vernacular names
- Scientific names
- iNaturalist IDs (explained below)

Wikidata was chosen because it can fetch data for multiple taxa at once and includes links to other data sources.

---

### SPARQL Query to Fetch Taxon Information

```sparql
SELECT ?taxon ?taxonLabel ?gbifID ?iNatID ?scientificName ?rankLabel
WHERE {
  VALUES ?gbifID { "2435099" "5219404" "2437894" "2440020" }

  ?taxon wdt\:P846 ?gbifID .              # GBIF taxon ID
  OPTIONAL { ?taxon wdt\:P3151 ?iNatID . } # iNaturalist taxon ID
  OPTIONAL { ?taxon wdt\:P225 ?scientificName . }  # Scientific name
  OPTIONAL { ?taxon wdt\:P105 ?rank . }    # Taxonomic rank

  SERVICE wikibase\:label { bd\:serviceParam wikibase\:language "en,fr". }
}
```

---

### Why the iNaturalist ID?

Wikidata does not always provide all taxonomic ranks. To fill in these gaps without making too many queries, we use the iNaturalist API, which allows us to fetch information for up to 30 taxa in a single request.
